### PR TITLE
Build variants first try

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -14,3 +14,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '2.7'
+variant_str:
+- gpu
+variant_version:
+- '0.0'

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -14,3 +14,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '3.6'
+variant_str:
+- gpu
+variant_version:
+- '0.0'

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -14,3 +14,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '3.7'
+variant_str:
+- gpu
+variant_version:
+- '0.0'

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -18,3 +18,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '2.7'
+variant_str:
+- gpu
+variant_version:
+- '0.0'

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -18,3 +18,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '3.6'
+variant_str:
+- gpu
+variant_version:
+- '0.0'

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -18,3 +18,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '3.7'
+variant_str:
+- gpu
+variant_version:
+- '0.0'

--- a/.ci_support/win_python3.6.yaml
+++ b/.ci_support/win_python3.6.yaml
@@ -12,6 +12,10 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '3.6'
+variant_str:
+- gpu
+variant_version:
+- '0.0'
 zip_keys:
 - - python
   - c_compiler

--- a/.ci_support/win_python3.7.yaml
+++ b/.ci_support/win_python3.7.yaml
@@ -12,6 +12,10 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '3.7'
+variant_str:
+- gpu
+variant_version:
+- '0.0'
 zip_keys:
 - - python
   - c_compiler

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # -*- mode: jinja -*-
 -->
 
-About pytorch-cpu
+About pytorch-gpu
 =================
 
 Home: https://pytorch.org/
@@ -25,27 +25,29 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-pytorch--cpu-green.svg)](https://anaconda.org/conda-forge/pytorch-cpu) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pytorch-cpu.svg)](https://anaconda.org/conda-forge/pytorch-cpu) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pytorch-cpu.svg)](https://anaconda.org/conda-forge/pytorch-cpu) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pytorch-cpu.svg)](https://anaconda.org/conda-forge/pytorch-cpu) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-_pytorch_variant-green.svg)](https://anaconda.org/conda-forge/_pytorch_variant) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/_pytorch_variant.svg)](https://anaconda.org/conda-forge/_pytorch_variant) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/_pytorch_variant.svg)](https://anaconda.org/conda-forge/_pytorch_variant) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/_pytorch_variant.svg)](https://anaconda.org/conda-forge/_pytorch_variant) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pytorch-green.svg)](https://anaconda.org/conda-forge/pytorch) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pytorch.svg)](https://anaconda.org/conda-forge/pytorch) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pytorch.svg)](https://anaconda.org/conda-forge/pytorch) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pytorch.svg)](https://anaconda.org/conda-forge/pytorch) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pytorch--gpu-green.svg)](https://anaconda.org/conda-forge/pytorch-gpu) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pytorch-gpu.svg)](https://anaconda.org/conda-forge/pytorch-gpu) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pytorch-gpu.svg)](https://anaconda.org/conda-forge/pytorch-gpu) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pytorch-gpu.svg)](https://anaconda.org/conda-forge/pytorch-gpu) |
 
-Installing pytorch-cpu
+Installing pytorch-gpu
 ======================
 
-Installing `pytorch-cpu` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `pytorch-gpu` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `pytorch-cpu` can be installed with:
+Once the `conda-forge` channel has been enabled, `_pytorch_variant, pytorch, pytorch-gpu` can be installed with:
 
 ```
-conda install pytorch-cpu
+conda install _pytorch_variant pytorch pytorch-gpu
 ```
 
-It is possible to list all of the versions of `pytorch-cpu` available on your platform with:
+It is possible to list all of the versions of `_pytorch_variant` available on your platform with:
 
 ```
-conda search pytorch-cpu --channel conda-forge
+conda search _pytorch_variant --channel conda-forge
 ```
 
 
@@ -87,17 +89,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating pytorch-cpu-feedstock
+Updating pytorch-gpu-feedstock
 ==============================
 
-If you would like to improve the pytorch-cpu recipe or build a new
+If you would like to improve the pytorch-gpu recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/pytorch-cpu-feedstock are
+Note that all branches in the conda-forge/pytorch-gpu-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
-# Windows builds of pytorch with python 2.7 are very experimental.
+  # Windows builds of pytorch with python 2.7 are very experimental.
 # Finally, pytorch requires MSVC2017
 # As of making this recipe, it only exists on defaults.
 # Leave conda_build_config.yaml alone unless it is windows
@@ -14,3 +14,15 @@ vc:                            # [win]
 python:                        # [win]
   - 3.6                        # [win]
   - 3.7                        # [win]
+
+
+variant_version:
+  - 0.0
+# - 1.0
+variant_str:
+  - gpu
+# - cpu
+    # zip_keys:
+    # - pytorch_variant
+    # - variant_version
+    # - variant_str

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,8 +64,8 @@ build:
     # which is their preferred method of building
     # that said, it does nothing but call "ninja"
     # - pip install ninja
-    - "{{ PYTHON }} -m pip install . --no-deps -vv --disable-pip-version-check"
-
+    # gpu version is just a stub
+    - "{{ PYTHON }} -m pip install . --no-deps -vv --disable-pip-version-check"  # [variant_str == 'cpu']
 requirements:
   build:
     - {{ compiler('c') }}
@@ -96,7 +96,7 @@ requirements:
 
 test:
   imports:
-    - torch
+    - torch  # [variant_str == 'cpu']
     # Maybe we should have a test for a simple Neural Network???
 
 outputs:
@@ -109,7 +109,7 @@ outputs:
         - pytorch-gpu   # [variant_str == 'gpu']
     test:
       imports:
-        - pytorch
+        - pytorch  # [variant == 'gpu']
     extra:
       pytorch_variant: {{ variant_str }}
   - name: _pytorch_variant

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ build:
   skip: true  # [win and py27]
   # remove this when we settle on the actual organization
   skip: true  # [variant_str == 'cpu']
+  skip: true  # [variant_str == 'gpu']
   script:
     # Most of this script is adapted from the pytorch/pythorch-cpu
     # meta.yaml.template build.sh and bld.bat scripts

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,23 +100,23 @@ test:
     # Maybe we should have a test for a simple Neural Network???
 
 outputs:
-  -name: pytorch-{{ variant_str }}
-  -name: pytorch
-   requirements:
-     run:
-       - _pytorch_variant ==0={{ variant_str }}
-       - pytorch-cpu   # [variant_str == 'cpu']
-       - pytorch-gpu   # [variant_str == 'gpu']
-   test:
-     imports:
-       - pytorch
-   extra:
-     pytorch_variant: {{ variant_str }}
-  -name: _pytorch_variant
-   version: {{ variant_version }}
-   build:
-     number: 0
-     string: {{ variant_str }}
+  - name: pytorch-{{ variant_str }}
+  - name: pytorch
+    requirements:
+      run:
+        - _pytorch_variant ==0={{ variant_str }}
+        - pytorch-cpu   # [variant_str == 'cpu']
+        - pytorch-gpu   # [variant_str == 'gpu']
+    test:
+      imports:
+        - pytorch
+    extra:
+      pytorch_variant: {{ variant_str }}
+  - name: _pytorch_variant
+    version: {{ variant_version }}
+    build:
+      number: 0
+      string: {{ variant_str }}
 
 about:
   home: https://pytorch.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "1.0.1" %}
 
 package:
-  name: pytorch-{{ variant_str }}
+  name: pytorch
   version: {{ version }}
 
 source:
@@ -23,6 +23,7 @@ build:
   # Support for Windows and Python 2.7 is very experimental
   # https://ci.appveyor.com/project/conda-forge/staged-recipes/builds/21220961#L972
   skip: true  # [win and py27]
+  # remove this when we settle on the actual organization
   skip: true  # [variant_str == 'cpu']
   script:
     # Most of this script is adapted from the pytorch/pythorch-cpu
@@ -33,7 +34,6 @@ build:
     - {{ export }} PYTORCH_BUILD_VERSION={{ PKG_VERSION }}
     - {{ export }} PYTORCH_BUILD_NUMBER={{ PKG_BUILDNUM }}
     - {{ export }} BUILD_CUSTOM_PROTOBUF=ON
-    # Use ninja as the build just won't finish on windows
     - {{ export }} CMAKE_GENERATOR=Ninja
     # I have no idea what this flag does, but they recommend turning it on
     # when we don't find three of their headers.
@@ -93,6 +93,8 @@ requirements:
     # ninja and cffi are included in
     - ninja
     - cffi
+    - pytorch-cpu   # [variant_str == 'cpu']
+    - pytorch-gpu   # [variant_str == 'gpu']
 
 test:
   imports:
@@ -100,16 +102,15 @@ test:
     # Maybe we should have a test for a simple Neural Network???
 
 outputs:
-  - name: pytorch-{{ variant_str }}
   - name: pytorch
+  - name: pytorch-{{ variant_str }}
     requirements:
       run:
         - _pytorch_variant ==0={{ variant_str }}
-        - pytorch-cpu   # [variant_str == 'cpu']
-        - pytorch-gpu   # [variant_str == 'gpu']
     test:
       imports:
-        - pytorch  # [variant == 'gpu']
+        # For now, gpu is only built using the pytorch channel
+        - pytorch  # [variant == 'cpu']
     extra:
       pytorch_variant: {{ variant_str }}
   - name: _pytorch_variant

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "1.0.1" %}
 
 package:
-  name: pytorch-cpu
+  name: pytorch-{{ variant_str }}
   version: {{ version }}
 
 source:
@@ -23,6 +23,7 @@ build:
   # Support for Windows and Python 2.7 is very experimental
   # https://ci.appveyor.com/project/conda-forge/staged-recipes/builds/21220961#L972
   skip: true  # [win and py27]
+  skip: true  # [variant_str == 'cpu']
   script:
     # Most of this script is adapted from the pytorch/pythorch-cpu
     # meta.yaml.template build.sh and bld.bat scripts
@@ -98,6 +99,25 @@ test:
     - torch
     # Maybe we should have a test for a simple Neural Network???
 
+outputs:
+  -name: pytorch-{{ variant_str }}
+  -name: pytorch
+   requirements:
+     run:
+       - _pytorch_variant ==0={{ variant_str }}
+       - pytorch-cpu   # [variant_str == 'cpu']
+       - pytorch-gpu   # [variant_str == 'gpu']
+   test:
+     imports:
+       - pytorch
+   extra:
+     pytorch_variant: {{ variant_str }}
+  -name: _pytorch_variant
+   version: {{ variant_version }}
+   build:
+     number: 0
+     string: {{ variant_str }}
+
 about:
   home: https://pytorch.org/
   license: BSD-3-Clause
@@ -106,6 +126,7 @@ about:
   summary: "PyTorch is an optimized tensor library for deep learning using GPUs and CPUs."
 
 extra:
+  pytorch_variant: {{ variant_str }}
   recipe-maintainers:
     - hmaarrfk
     - sodre


### PR DESCRIPTION
@jjhelmus any idea what i'm doing worng here?

I'm trying to follow your build variant package here (just all mangled with multiple outputs recipes) but it seems that my keys aren't getting recognized:

<details> 

```
mark2@xps ~/g/f/pytorch-cpu-feedstock build_variants|⚑ 2                                                                                                                                                        
$ conda smithy rerender                                                                                                                                                                                         
## CONFIGURATION USED

appveyor:
  image: Visual Studio 2017
  secure: {BINSTAR_TOKEN: tumuXLL8PU75WMnRDemRy02ruEq2RpNxeK3dz0MjFssnosPm2v4EFjfNB4PTotA1}
azure: {force: false, upload_packages: true}
channels:
  sources: [conda-forge, defaults]
  targets:
  - [conda-forge, main]
circle: {}
compiler_stack: comp7
docker: {command: bash, executable: docker, image: condaforge/linux-anvil-comp7, interactive: true}
github: {branch_name: master, repo_name: '', user_or_org: conda-forge}
idle_timeout_minutes: null
linux: {enabled: false}
linux_aarch64: {enabled: false}
linux_ppc64le: {enabled: false}
max_py_ver: '37'
max_r_ver: '35'
min_py_ver: '27'
min_r_ver: '34'
osx: {enabled: false}
provider: {linux: circle, linux_aarch64: null, linux_ppc64le: null, osx: circle, win: azure}
recipe_dir: recipe
templates: {}
travis:
  secure: {BINSTAR_TOKEN: FdQUTwWxz9QD350vPgck9v+THL6+qphek2OFXsP/NHMLTTy4q7k77w5MmAZpwPMTyw3maxDljzXkj1Wcs/F1+0lMRU5AfaE5Jjr8hJ/YTKjtAB6XOyNaRUh+WzA/qi6YorryHb9Vv1ZJie15Zwzv7ge0LXlfEpZqaSbFMWv8r3e/fhEiIA8Hs8aFvv4ei/RFCp+Zo4Iu80TORxrDpYmoKJwmZXATCyBZt9wHVZuPE65dyF84ffxB49K+0G0Ggt860iq27DT0zDw5Mj0D5TMRiTb6Y8Rvj7OUXeTzlSbYFMAVnyZ7tJObdjv2IYW1mEIXw0k1utoxuiONNeED4vhCH1QoZ2dDZo5tnmgvd+C9zVZq7gcNrIjZXalClidBvzjqGd7np/fCUU1ga8MSLQnWHAcGEyIo12XzYGsogiRLQWq0qgBND5oFv6ePKK/tlALp7I5XdGbNwrlmXbseDoTVVnBml64QqDjWsd29yHBqxe7EpA6i+VQjZYxP41mhu/kbRYHCNKK9Hldr8ywhpvgTVYOFT+y9P5S3zUOAeJFcHmIYsdqTpMgd/fU2qNwfcazmGNgycxTHYRTBw8gya0Leof7QEINKijDjWBJqKpTW341oyGaB/uvxExE2PABmesOU3sFJHicrQKn3BdDmonE7agY3r5MU55dqEv5lCGjXXd8=}
win: {enabled: false}

## END CONFIGURATION

Setting build platform. This is only useful when pretending to be on another platform, such as for rendering necessary dependencies on a non-native platform. I trust that you know what you're doing.
Setting build arch. This is only useful when pretending to be on another arch, such as for rendering necessary dependencies on a non-native arch. I trust that you know what you're doing.
No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.11
Problematic recipe:


package:
  name: pytorch-
  version: 1.0.1

source:
  git_url: https://github.com/pytorch/pytorch.git
  git_tag: v1.0.1



build:
  number: 0
  script:
    - export TN_BINARY_BUILD=1
    - export PYTORCH_BINARY_BUILD=1
    - export NO_CUDA=1
    - export PYTORCH_BUILD_VERSION=
    - export PYTORCH_BUILD_NUMBER=0
    - export BUILD_CUSTOM_PROTOBUF=ON
    - export CMAKE_GENERATOR=Ninja
    - export CXXFLAGS="-Wno-error=unused-result $CXXFLAGS"
    - export CFLAGS="-Wno-error=unused-result $CFLAGS"
    - export NO_MKLDNN=1
    - export EXTRA_CAFFE2_CMAKE_FLAGS="-DUSE_MPI=OFF -DUSE_NUMA=OFF -DUSE_NCCL=OFF -DATEN_NO_TEST=OFF"
    - export CXXFLAGS="-I/home/mark2/miniconda3/conda-bld/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place/include/ $CXXFLAGS"
    - export CFLAGS="-I/home/mark2/miniconda3/conda-bld/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place/include/ $CFLAGS"
    - " -m pip install . --no-deps -vv --disable-pip-version-check"

requirements:
  build:
    - gcc_linux-64
    - gxx_linux-64
    - cmake
    - ninja
    - make
  host:
    - python
    - pip
    - pyyaml
    - numpy 1.11
    - setuptools
    - cffi
    - ninja
    - pybind11
  run:
    - python
    - numpy
    - ninja
    - cffi

test:
  imports:
    - torch

outputs:
  -name: pytorch-
  -name: pytorch
   requirements:
     run:
       - _pytorch_variant ==0=
   test:
     imports:
       - pytorch
   extra:
     pytorch_variant:
  -name: _pytorch_variant
   version:
   build:
     number: 0
     string:

about:
  home: https://pytorch.org/
  license: BSD-3-Clause
  license_family: BSD
  license_file: LICENSE
  summary: "PyTorch is an optimized tensor library for deep learning using GPUs and CPUs."

extra:
  pytorch_variant:
  recipe-maintainers:
    - hmaarrfk
    - sodre

----------------------------------------------------------------------
Unable to parse meta.yaml file

Error Message:
--> mapping values are not allowed in this context
-->   in "<unicode string>", line 60, column 16


```

</details>


Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
