### PR TITLE
[ci-skip] [skip-ci] Add typing_extensions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     - fix_msvc_build_issue.diff
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: pytorch
@@ -95,6 +95,7 @@ outputs:
         # the user an error
         - future
         - typing  # [py2k]
+        - typing_extensions
         # Need ninja to load C++ extensions
         - ninja
 


### PR DESCRIPTION
If we are patching the metadata, do we need to bump the build number?
https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/108
@isuruf 
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
