### PR TITLE
Try building without tests

### DIFF
--- a/recipe/build_pytorch.sh
+++ b/recipe/build_pytorch.sh
@@ -47,6 +47,7 @@ export PYTORCH_BUILD_NUMBER=$PKG_BUILDNUM
 
 export USE_NINJA=OFF
 export INSTALL_TEST=0
+export BUILD_TEST=0
 
 export USE_SYSTEM_SLEEF=1
 # use our protobuf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - fix_blas_lapack.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('pytorch', max_pin='x.x.x') }}
   skip: true  # [win]


### PR DESCRIPTION
In the build logs, I'm trying to avoid building files like:

```
  [5122/5468] Linking CXX executable bin/elementwise_op_test                                               
  [5123/5468] Linking CXX executable bin/boolean_unmask_ops_test                                         
[...]
  [5167/5468] Building CXX object test_jit/CMakeFiles/test_jit.dir/test_custom_class_registrations.cpp.o

```

This build
```
  [4328/4329] Install the project...
```

Previous build (master):
```
  [4800/4801] Install the project...
```

Saving 450 compilation files seems worthwhile to me.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
