### PR TITLE
Add run exports correctly

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -99,6 +99,13 @@ outputs:
         # other requirements
         - python
         - {{ pin_compatible('numpy') }}
+        # hmaarrfk 2021/12/28
+        # it seems that pytorch uses some aspects of setuptools
+        # that were removed in version 59.6
+        # I'm not really inclined to patch this out since
+        # this is a pretty easy build time dependency
+        # https://github.com/pytorch/pytorch/issues/69894
+        - setuptools <59.6
         - cffi
         # if future isn't installed on python 3, `pip check` can give
         # the user an error

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,7 @@ source:
     - fix_dispatch_apply_auto.patch
 
 build:
-  number: 0
-  run_exports:
-    - {{ pin_subpackage('pytorch', max_pin='x.x') }}
+  number: 1
   skip: true  # [win]
 
 outputs:
@@ -23,6 +21,8 @@ outputs:
       string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
       string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                      # [cuda_compiler_version == "None"]
       detect_binary_files_with_prefix: false
+      run_exports:
+        - {{ pin_subpackage('pytorch', max_pin='x.x') }}
     script: build_pytorch.sh  # [not win]
     script: bld_pytorch.bat   # [win]
     requirements:


### PR DESCRIPTION
This is why the pinnings are failing... it was in the wrong location

cc: @h-vetinari


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
