### PR TITLE
 [ci skip] [skip ci] [cf admin skip] ***NO_CI*** add track_feature to cpu builds to deprioritize them

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - fix_dispatch_apply_auto.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 outputs:
@@ -23,6 +23,8 @@ outputs:
       detect_binary_files_with_prefix: false
       run_exports:
         - {{ pin_subpackage('pytorch', max_pin='x.x') }}
+      track_features:
+        - pytorch-cpu                                      # [cuda_compiler_version == "None"]
     script: build_pytorch.sh  # [not win]
     script: bld_pytorch.bat   # [win]
     requirements:
@@ -109,6 +111,8 @@ outputs:
         - typing_extensions
         # Need ninja to load C++ extensions
         - ninja
+        # avoid that people without GPUs needlessly download ~0.5-1GB
+        - __cuda  # [cuda_compiler_version != "None"]
       run_constrained:
         # These constraints ensure conflict between pytorch and
         # pytorch-cpu 1.1 which we built before conda-forge had GPU infrastructure


### PR DESCRIPTION
Closes https://github.com/conda-forge/pytorch-cpu-feedstock/issues/71

cc: @adamjstewart @ashnair1 

I'm asking the bot to skip these builds so that we can do a repo-patch instead. I'm worried that the increased build number will cause some solver confusion. Honestly, i also can't dedicate resources to building tis for an entire day or two this week.

repodata patch: https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/265
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
