### PR TITLE
Update feedstock to use cirun-openstack-gpu-large with Cirun

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -18,7 +18,12 @@ os_version:
   linux_64: cos7
 provider:
   linux_aarch64: azure
+  linux_64: github_actions
 remote_ci_setup:
 - py-lief=0.12.3
 - conda-forge-ci-setup=3
 test_on_native_only: true
+github_actions:
+  self_hosted: true
+upload_on_branch:
+- main

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,13 +1,15 @@
 MACOSX_SDK_VERSION:         # [osx]
-  - 12.3                    # [osx]
+- 12.3                      # [osx]
 
 # It seems that clang 16 might be a little too strict for
 # some pointer conversions
 c_compiler_version:         # [osx]
-  - 15                      # [osx]
+- 15                        # [osx]
 cxx_compiler_version:       # [osx]
-  - 15                      # [osx]
+- 15                        # [osx]
 
 blas_impl:
-  - mkl                        # [x86 or x86_64]
-  - generic
+- mkl                          # [x86 or x86_64]
+- generic
+github_actions_labels:
+- cirun-openstack-gpu-large


### PR DESCRIPTION

Note that only builds triggered by maintainers of the feedstock (and core)
who have accepted the terms of service and privacy policy will run
on Github actions via Cirun.
- [ ] Maintainers have accepted the terms of service and privacy policy
  at https://github.com/Quansight/open-gpu-server
