### PR TITLE
Don't bundle Python dependencies on osx

### DIFF
--- a/recipe/build_pytorch.sh
+++ b/recipe/build_pytorch.sh
@@ -9,5 +9,5 @@ if [[ "$megabuild" == true ]]; then
     fi
   done
 else
-  $PREFIX/bin/python -m pip install torch-*.whl
+  $PREFIX/bin/python -m pip install --no-deps torch-*.whl
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2.1.2" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% if cuda_compiler_version != "None" %}
 {% set build = build + 200 %}


### PR DESCRIPTION
Since https://github.com/conda-forge/pytorch-cpu-feedstock/pull/210, this packages bundles all Python dependencies inside the package on `osx`. Therefore, I would mark all of the osx builds since then as broken. Linux shouldn't be affected.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
