### PR TITLE
fix: use tarball instead of git source

### DIFF
--- a/.ci_support/linux_64_blas_implgenericc_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '10'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -59,6 +63,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
   - cdt_name
   - cuda_compiler
   - cuda_compiler_version

--- a/.ci_support/linux_64_blas_implgenericc_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '11'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -59,6 +63,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
   - cdt_name
   - cuda_compiler
   - cuda_compiler_version

--- a/.ci_support/linux_64_blas_implgenericc_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -59,6 +63,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
   - cdt_name
   - cuda_compiler
   - cuda_compiler_version

--- a/.ci_support/linux_64_blas_implgenericc_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -59,6 +63,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
   - cdt_name
   - cuda_compiler
   - cuda_compiler_version

--- a/.ci_support/linux_64_blas_implmklc_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '10'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -59,6 +63,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
   - cdt_name
   - cuda_compiler
   - cuda_compiler_version

--- a/.ci_support/linux_64_blas_implmklc_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '11'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -59,6 +63,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
   - cdt_name
   - cuda_compiler
   - cuda_compiler_version

--- a/.ci_support/linux_64_blas_implmklc_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -59,6 +63,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
   - cdt_name
   - cuda_compiler
   - cuda_compiler_version

--- a/.ci_support/linux_64_blas_implmklc_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -59,6 +63,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
   - cdt_name
   - cuda_compiler
   - cuda_compiler_version

--- a/.ci_support/linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -6,6 +6,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '10'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -63,6 +67,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
   - cdt_name
   - cuda_compiler
   - cuda_compiler_version

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12.yaml
@@ -6,6 +6,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -63,6 +67,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
   - cdt_name
   - cuda_compiler
   - cuda_compiler_version

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
@@ -6,6 +6,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -63,6 +67,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - c_stdlib_version
   - cdt_name
   - cuda_compiler
   - cuda_compiler_version

--- a/.ci_support/osx_64_blas_implgenericnumpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy1.22python3.10.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_blas_implgenericnumpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy1.22python3.8.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_blas_implgenericnumpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy1.22python3.9.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_blas_implgenericnumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy1.23python3.11.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_blas_implgenericnumpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy1.26python3.12.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_blas_implmklnumpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy1.22python3.10.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_blas_implmklnumpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy1.22python3.8.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_blas_implmklnumpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy1.22python3.9.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_blas_implmklnumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy1.23python3.11.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_blas_implmklnumpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy1.26python3.12.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.8.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '15'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Tobias-Fischer @beckermr @benjaminrwilson @hmaarrfk @sodre
+* @Tobias-Fischer @baszalmstra @beckermr @benjaminrwilson @hmaarrfk @sodre

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -70,11 +70,6 @@ jobs:
             os: ubuntu
             runs_on: ['cirun-openstack-cpu-large--${{ github.run_id }}-linux_aarch64_c_compiler_version10c_hb0ea797ce5', 'linux', 'x64', 'self-hosted']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
-          - CONFIG: linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11
-            UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['cirun-openstack-cpu-large--${{ github.run_id }}-linux_aarch64_c_compiler_version11c_h16465f209e', 'linux', 'x64', 'self-hosted']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.8
           - CONFIG: linux_aarch64_c_compiler_version12cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12
             UPLOAD_PACKAGES: True
             os: ubuntu

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Feedstock Maintainers
 =====================
 
 * [@Tobias-Fischer](https://github.com/Tobias-Fischer/)
+* [@baszalmstra](https://github.com/baszalmstra/)
 * [@beckermr](https://github.com/beckermr/)
 * [@benjaminrwilson](https://github.com/benjaminrwilson/)
 * [@hmaarrfk](https://github.com/hmaarrfk/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2.1.2" %}
-{% set build = 3 %}
+{% set build = 4 %}
 
 {% if cuda_compiler_version != "None" %}
 {% set build = build + 200 %}
@@ -20,9 +20,8 @@ package:
   version: {{ version }}
 
 source:
-  # for local testing use a tarball including submodules
-  git_url: https://github.com/pytorch/pytorch.git
-  git_tag: v{{ version }}
+  url: https://github.com/pytorch/pytorch/releases/download/v{{ version }}/pytorch-v{{ version }}.tar.gz
+  sha256: 57a1136095bdfe769acb87876dce77212da2c995c61957a67a1f16172d235d17
   patches:
     - patches/nvml.patch  # [cuda_compiler_version == "11.2"]
     # The patch below is probably OK for other versions too, but it is untested with them
@@ -350,4 +349,5 @@ extra:
     - benjaminrwilson
     - Tobias-Fischer
     - beckermr
+    - baszalmstra
   feedstock-name: pytorch-cpu

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ package:
 
 source:
   url: https://github.com/pytorch/pytorch/releases/download/v{{ version }}/pytorch-v{{ version }}.tar.gz
-  sha256: 57a1136095bdfe769acb87876dce77212da2c995c61957a67a1f16172d235d17
+  sha256: 85effbcce037bffa290aea775c9a4bad5f769cb229583450c40055501ee1acd7
   patches:
     - patches/nvml.patch  # [cuda_compiler_version == "11.2"]
     # The patch below is probably OK for other versions too, but it is untested with them


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This PR is an attempt to reduce the time it takes to download the source from git by downloading a tarball provided with the release instead. This tarball includes all submodules and is created for every release. The downside is that it also contains symlinks which might be a problem on windows.