### PR TITLE
Allow CUDA path override only during package build

### DIFF
--- a/.ci_support/linux_64_blas_implgenericc_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12.yaml
@@ -36,6 +36,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 megabuild:
 - 'true'
 mkl:
@@ -48,8 +50,6 @@ numpy:
 - '2.0'
 - '2'
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_blas_implgenericc_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13.yaml
@@ -36,6 +36,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 megabuild:
 - 'true'
 mkl:
@@ -48,8 +50,6 @@ numpy:
 - '2.0'
 - '2'
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_blas_implmklc_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12.yaml
@@ -36,6 +36,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 megabuild:
 - 'true'
 mkl:
@@ -48,8 +50,6 @@ numpy:
 - '2.0'
 - '2'
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_blas_implmklc_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13.yaml
@@ -36,6 +36,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 megabuild:
 - 'true'
 mkl:
@@ -48,8 +50,6 @@ numpy:
 - '2.0'
 - '2'
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12.yaml
@@ -36,6 +36,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 megabuild:
 - 'true'
 mkl:
@@ -48,8 +50,6 @@ numpy:
 - '2.0'
 - '2'
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13.yaml
@@ -36,6 +36,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 megabuild:
 - 'true'
 mkl:
@@ -48,8 +50,6 @@ numpy:
 - '2.0'
 - '2'
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_blas_implgenericnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy2.0python3.10.____cpython.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_blas_implgenericnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy2.0python3.11.____cpython.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_blas_implgenericnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy2.0python3.12.____cpython.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_blas_implgenericnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy2.0python3.9.____cpython.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_blas_implgenericnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy2python3.13.____cp313.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_blas_implmklnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy2.0python3.10.____cpython.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_blas_implmklnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy2.0python3.11.____cpython.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_blas_implmklnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy2.0python3.12.____cpython.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_blas_implmklnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy2.0python3.9.____cpython.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_blas_implmklnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy2python3.13.____cp313.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_numpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.10.____cpython.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_numpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.11.____cpython.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_numpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.12.____cpython.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_numpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.9.____cpython.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2.0'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_numpy2python3.13.____cp313.yaml
@@ -32,6 +32,8 @@ liblapack:
 - 3.9 *netlib
 libprotobuf:
 - 5.28.2
+libtorch:
+- '2.4'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -42,8 +44,6 @@ mkl:
 - '2023'
 numpy:
 - '2'
-orc:
-- 2.0.3
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # This is used to detect if it's in the process of building pytorch
-export IN_PYTORCH_BUILD
+export IN_PYTORCH_BUILD=1
 
 # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/243
 # https://github.com/pytorch/pytorch/blob/v2.3.1/setup.py#L341

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+# This is used to detect if it's in the process of building pytorch
 export IN_PYTORCH_BUILD
 
 # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/243

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+export IN_PYTORCH_BUILD
+
 # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/243
 # https://github.com/pytorch/pytorch/blob/v2.3.1/setup.py#L341
 export PACKAGE_TYPE=conda

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2.5.1" %}
-{% set build = 5 %}
+{% set build = 6 %}
 
 {% if cuda_compiler_version != "None" %}
 {% set build = build + 200 %}

--- a/recipe/patches/0010-Allow-overriding-CUDA-related-paths.patch
+++ b/recipe/patches/0010-Allow-overriding-CUDA-related-paths.patch
@@ -17,7 +17,7 @@ index ec9ae530..76d1fb9a 100644
  # We compute the rest based on those here to avoid re-searching and to avoid finding a possibly
  # different installation.
 -if(CMAKE_CUDA_COMPILER_TOOLKIT_ROOT)
-+if(FALSE)
++if(CMAKE_CUDA_COMPILER_TOOLKIT_ROOT AND NOT $ENV{IN_PYTORCH_BUILD})
    set(CUDAToolkit_ROOT_DIR "${CMAKE_CUDA_COMPILER_TOOLKIT_ROOT}")
    set(CUDAToolkit_LIBRARY_ROOT "${CMAKE_CUDA_COMPILER_LIBRARY_ROOT}")
    set(CUDAToolkit_VERSION "${CMAKE_CUDA_COMPILER_TOOLKIT_VERSION}")

--- a/recipe/patches/0010-Allow-overriding-CUDA-related-paths.patch
+++ b/recipe/patches/0010-Allow-overriding-CUDA-related-paths.patch
@@ -17,7 +17,7 @@ index ec9ae530..76d1fb9a 100644
  # We compute the rest based on those here to avoid re-searching and to avoid finding a possibly
  # different installation.
 -if(CMAKE_CUDA_COMPILER_TOOLKIT_ROOT)
-+if(CMAKE_CUDA_COMPILER_TOOLKIT_ROOT AND NOT ENV{IN_PYTORCH_BUILD})
++if(CMAKE_CUDA_COMPILER_TOOLKIT_ROOT AND NOT $ENV{IN_PYTORCH_BUILD})
    set(CUDAToolkit_ROOT_DIR "${CMAKE_CUDA_COMPILER_TOOLKIT_ROOT}")
    set(CUDAToolkit_LIBRARY_ROOT "${CMAKE_CUDA_COMPILER_LIBRARY_ROOT}")
    set(CUDAToolkit_VERSION "${CMAKE_CUDA_COMPILER_TOOLKIT_VERSION}")

--- a/recipe/patches/0010-Allow-overriding-CUDA-related-paths.patch
+++ b/recipe/patches/0010-Allow-overriding-CUDA-related-paths.patch
@@ -17,7 +17,7 @@ index ec9ae530..76d1fb9a 100644
  # We compute the rest based on those here to avoid re-searching and to avoid finding a possibly
  # different installation.
 -if(CMAKE_CUDA_COMPILER_TOOLKIT_ROOT)
-+if(CMAKE_CUDA_COMPILER_TOOLKIT_ROOT AND NOT $ENV{IN_PYTORCH_BUILD})
++if(CMAKE_CUDA_COMPILER_TOOLKIT_ROOT AND NOT "$ENV{IN_PYTORCH_BUILD}" STREQUAL "1")
    set(CUDAToolkit_ROOT_DIR "${CMAKE_CUDA_COMPILER_TOOLKIT_ROOT}")
    set(CUDAToolkit_LIBRARY_ROOT "${CMAKE_CUDA_COMPILER_LIBRARY_ROOT}")
    set(CUDAToolkit_VERSION "${CMAKE_CUDA_COMPILER_TOOLKIT_VERSION}")

--- a/recipe/patches/0010-Allow-overriding-CUDA-related-paths.patch
+++ b/recipe/patches/0010-Allow-overriding-CUDA-related-paths.patch
@@ -17,7 +17,7 @@ index ec9ae530..76d1fb9a 100644
  # We compute the rest based on those here to avoid re-searching and to avoid finding a possibly
  # different installation.
 -if(CMAKE_CUDA_COMPILER_TOOLKIT_ROOT)
-+if(CMAKE_CUDA_COMPILER_TOOLKIT_ROOT AND NOT $ENV{IN_PYTORCH_BUILD})
++if(CMAKE_CUDA_COMPILER_TOOLKIT_ROOT AND NOT ENV{IN_PYTORCH_BUILD})
    set(CUDAToolkit_ROOT_DIR "${CMAKE_CUDA_COMPILER_TOOLKIT_ROOT}")
    set(CUDAToolkit_LIBRARY_ROOT "${CMAKE_CUDA_COMPILER_LIBRARY_ROOT}")
    set(CUDAToolkit_VERSION "${CMAKE_CUDA_COMPILER_TOOLKIT_VERSION}")


### PR DESCRIPTION
It seems the modification to `FindCUDAToolkit.cmake` in https://github.com/conda-forge/pytorch-cpu-feedstock/commit/55c97fe71c062d6cf81b6cc554759ee1c03b5b26#r150044376 has caused downstream build failures:
- https://github.com/conda-forge/torchaudio-feedstock/pull/12#discussion_r1870665348
- https://github.com/facebookincubator/momentum/actions/runs/12207717521/job/34059648061#step:8:3777

The key issues are that the modification alters the behavior of finding CUDAToolkit paths and it is unclear whether this change was intended to affect downstream packages or if it was solely for building the package itself.

**Current "Fix"**: One possible solution is to modify the behavior only for building the pytorch package, while leaving the behavior unchanged when it's used by downstream packages. However, this may not be the ideal solution, and we would like to discuss alternative approaches.

Please share your thoughts and suggestions on how to proceed.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
