### PR TITLE
Reenable building kineto, add CUPTI dep

### DIFF
--- a/recipe/README.md
+++ b/recipe/README.md
@@ -80,6 +80,7 @@ of 2024-11-28:
 | Package   | Upstream       | Recipe | Conda-forge | Source                              |
 |-----------|----------------|--------|-------------|-------------------------------------|
 | cuda      | 11.8/12.1/12.4 | 12.6   | 12.6        | `.ci/docker/build.sh`               |
+| cuda-cupti| 12.4.127       |        | 12.6.80     | `.github/scripts/generate_binary_build_matrix.py` |
 | magma     | 2.6.1          |        | 2.8.0       | `.ci/docker/common/instal_magma.sh` |
 | libabseil | indirect?      |        | 20240722.0  |                                     |
 | libuv     |                |        | 1.49.2      | (not pinned)                        |

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -36,12 +36,6 @@ fi
 # This is not correctly found for linux-aarch64 since pytorch 2.0.0 for some reason
 export _GLIBCXX_USE_CXX11_ABI=1
 
-# KINETO seems to require CUPTI and will look quite hard for it.
-# CUPTI seems to cause trouble when users install a version of
-# cudatoolkit different than the one specified at compile time.
-# https://github.com/conda-forge/pytorch-cpu-feedstock/issues/135
-export USE_KINETO=OFF
-
 if [[ "$target_platform" == "osx-64" ]]; then
   export CXXFLAGS="$CXXFLAGS -DTARGET_OS_OSX=1"
   export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1"
@@ -155,6 +149,8 @@ elif [[ ${cuda_compiler_version} != "None" ]]; then
     if [[ "${target_platform}" != "${build_platform}" ]]; then
         export CUDA_TOOLKIT_ROOT=${PREFIX}
     fi
+    # for CUPTI
+    export CUDA_TOOLKIT_ROOT_DIR=${PREFIX}
     case ${target_platform} in
         linux-64)
             export CUDAToolkit_TARGET_DIR=${PREFIX}/targets/x86_64-linux

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -97,6 +97,7 @@ requirements:
     {% if cuda_compiler_version != "None" %}
     - cuda-driver-dev
     - cuda-cudart-dev
+    - cuda-cupti-dev
     - cuda-nvrtc-dev
     - cuda-nvtx-dev
     - cuda-nvml-dev
@@ -198,6 +199,7 @@ outputs:
         {% if cuda_compiler_version != "None" %}
         - cuda-driver-dev
         - cuda-cudart-dev
+        - cuda-cupti-dev
         - cuda-nvrtc-dev
         - cuda-nvtx-dev
         - cuda-nvml-dev


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Fixes #76

Let's try enabling new dependencies separately, to see which one caused CI problems.