### PR TITLE
Build with `-Wl,-z,noexecstack` to fix glibc 2.41 compatibility

### DIFF
--- a/.ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
@@ -55,7 +55,7 @@ numpy:
 - '2'
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -80,3 +80,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
@@ -55,7 +55,7 @@ numpy:
 - '2'
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -80,3 +80,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/linux_64_blas_implmklc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
@@ -55,7 +55,7 @@ numpy:
 - '2'
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -80,3 +80,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/linux_64_blas_implmklc_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
@@ -55,7 +55,7 @@ numpy:
 - '2'
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -80,3 +80,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
@@ -55,7 +55,7 @@ numpy:
 - '2'
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -80,3 +80,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
@@ -55,7 +55,7 @@ numpy:
 - '2'
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -80,3 +80,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.10.____cpython.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.11.____cpython.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.12.____cpython.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.9.____cpython.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2python3.13.____cp313.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.10.____cpython.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.11.____cpython.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.12.____cpython.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.9.____cpython.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2python3.13.____cp313.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.10.____cpython.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.11.____cpython.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.12.____cpython.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.9.____cpython.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2python3.13.____cp313.yaml
@@ -49,7 +49,7 @@ mkl:
 numpy:
 - '2'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -67,3 +67,5 @@ zip_keys:
   - is_rc
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/win_64_channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNoneis_rcFalse.yaml
+++ b/.ci_support/win_64_channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNoneis_rcFalse.yaml
@@ -37,7 +37,7 @@ numpy:
 - '2'
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -59,3 +59,5 @@ zip_keys:
   - cuda_compiler_version
 - - python
   - numpy
+zlib:
+- '1'

--- a/.ci_support/win_64_channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6is_rcFalse.yaml
+++ b/.ci_support/win_64_channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6is_rcFalse.yaml
@@ -37,7 +37,7 @@ numpy:
 - '2'
 - '2.0'
 orc:
-- 2.0.3
+- 2.1.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -59,3 +59,5 @@ zip_keys:
   - cuda_compiler_version
 - - python
   - numpy
+zlib:
+- '1'

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -40,6 +40,9 @@ export LDFLAGS="$(echo $LDFLAGS | sed 's/-Wl,--as-needed//g')"
 # error on osx-64.
 export LDFLAGS="$(echo $LDFLAGS | sed 's/-Wl,-dead_strip_dylibs//g')"
 export LDFLAGS_LD="$(echo $LDFLAGS_LD | sed 's/-dead_strip_dylibs//g')"
+# Explicitly force non-executable stack to fix compatibility with glibc 2.41, due to:
+# ittptmark64.S.o: missing .note.GNU-stack section implies executable stack
+LDFLAGS+=" -Wl,-z,noexecstack"
 if [[ "$c_compiler" == "clang" ]]; then
     export CXXFLAGS="$CXXFLAGS -Wno-deprecated-declarations -Wno-unknown-warning-option -Wno-error=unused-command-line-argument -Wno-error=vla-cxx-extension"
     export CFLAGS="$CFLAGS -Wno-deprecated-declarations -Wno-unknown-warning-option -Wno-error=unused-command-line-argument -Wno-error=vla-cxx-extension"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # if you wish to build release candidate number X, append the version string with ".rcX"
 {% set version = "2.5.1" %}
-{% set build = 12 %}
+{% set build = 13 %}
 
 # Use a higher build number for the CUDA variant, to ensure that it's
 # preferred by conda's solver, and it's preferentially


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Explicitly pass `-Wl,-z,noexecstack` to the linker, to ensure that `libpytorch_cpu.so` is compiled without an executable stack.  This is necessary because the raw assembly in oneDNN triggers:

```
$BUILD_PREFIX/bin/../lib/gcc/x86_64-conda-linux-gnu/13.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: warning: ittptmark64.S.o: missing .note.GNU-stack section implies executable stack
```

...and glibc 2.41 no longer permits loading libraries with executable stack.

Fixes #350

