### PR TITLE
2.4.x kineto backport

### DIFF
--- a/.ci_support/linux_64_blas_implgenericc_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -37,7 +37,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 megabuild:
 - 'true'
 mkl:
@@ -61,7 +61,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implgenericc_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
@@ -37,7 +37,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 megabuild:
 - 'true'
 mkl:
@@ -61,7 +61,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implgenericc_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13.yaml
@@ -37,7 +37,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 megabuild:
 - 'true'
 mkl:
@@ -61,7 +61,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implmklc_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -37,7 +37,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 megabuild:
 - 'true'
 mkl:
@@ -61,7 +61,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implmklc_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
@@ -37,7 +37,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 megabuild:
 - 'true'
 mkl:
@@ -61,7 +61,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implmklc_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13.yaml
@@ -37,7 +37,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 megabuild:
 - 'true'
 mkl:
@@ -61,7 +61,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
@@ -37,7 +37,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 megabuild:
 - 'true'
 mkl:
@@ -61,7 +61,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13.yaml
@@ -37,7 +37,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 megabuild:
 - 'true'
 mkl:
@@ -61,7 +61,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/osx_64_blas_implgenericnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy2.0python3.10.____cpython.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implgenericnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy2.0python3.11.____cpython.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implgenericnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy2.0python3.12.____cpython.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implgenericnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy2.0python3.9.____cpython.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implgenericnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_blas_implgenericnumpy2python3.13.____cp313.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implmklnumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy2.0python3.10.____cpython.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implmklnumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy2.0python3.11.____cpython.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implmklnumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy2.0python3.12.____cpython.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implmklnumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy2.0python3.9.____cpython.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implmklnumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_blas_implmklnumpy2python3.13.____cp313.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_numpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.10.____cpython.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_numpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.11.____cpython.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_numpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.12.____cpython.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_numpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy2.0python3.9.____cpython.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_numpy2python3.13.____cp313.yaml
@@ -33,7 +33,7 @@ liblapack:
 libprotobuf:
 - 5.28.3
 libtorch:
-- '2.4'
+- '2.5'
 llvm_openmp:
 - '17'
 macos_machine:
@@ -51,7 +51,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 pytorch:
-- '2.4'
+- '2.5'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output
+# Pixi's configuration
+.pixi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,12 +30,6 @@ fi
 # This is not correctly found for linux-aarch64 since pytorch 2.0.0 for some reason
 export _GLIBCXX_USE_CXX11_ABI=1
 
-# KINETO seems to require CUPTI and will look quite hard for it.
-# CUPTI seems to cause trouble when users install a version of
-# cudatoolkit different than the one specified at compile time.
-# https://github.com/conda-forge/pytorch-cpu-feedstock/issues/135
-export USE_KINETO=OFF
-
 if [[ "$target_platform" == "osx-64" ]]; then
   export CXXFLAGS="$CXXFLAGS -DTARGET_OS_OSX=1"
   export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -39,6 +39,10 @@ export USE_KINETO=OFF
 if [[ "$target_platform" == "osx-64" ]]; then
   export CXXFLAGS="$CXXFLAGS -DTARGET_OS_OSX=1"
   export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1"
+elif [[ "$target_platform" == linux-* ]]; then
+    # Explicitly force non-executable stack to fix compatibility with glibc 2.41, due to:
+    # ittptmark64.S.o: missing .note.GNU-stack section implies executable stack
+    LDFLAGS="${LDFLAGS} -Wl,-z,noexecstack"
 fi
 
 # Dynamic libraries need to be lazily loaded so that torch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -345,8 +345,10 @@ outputs:
   {% set pytorch_cpu_gpu = "pytorch-gpu" %}   # [cuda_compiler_version != "None"]
   - name: {{ pytorch_cpu_gpu }}
     build:
-      string: cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}py{{ CONDA_PY }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
-      string: cpu_{{ blas_impl }}_py{{ CONDA_PY }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [cuda_compiler_version == "None"]
+      string: cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                  # [megabuild and cuda_compiler_version != "None"]
+      string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                                 # [megabuild and cuda_compiler_version == "None"]
+      string: cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}py{{ CONDA_PY }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [not megabuild and cuda_compiler_version != "None"]
+      string: cpu_{{ blas_impl }}_py{{ CONDA_PY }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [not megabuild and cuda_compiler_version == "None"]
       detect_binary_files_with_prefix: false
       skip: true  # [cuda_compiler_version != "None" and linux64 and blas_impl != "mkl"]
       # weigh down cpu implementation and give cuda preference

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,8 +51,8 @@ source:
 
 build:
   number: {{ build }}
-  string: cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
-  string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                 # [cuda_compiler_version == "None"]
+  string: cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}_h{{ PKG_HASH }}_{{ build }}  # [cuda_compiler_version != "None"]
+  string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ build }}                                                 # [cuda_compiler_version == "None"]
   detect_binary_files_with_prefix: false
   run_exports:
     - {{ pin_subpackage('libtorch', max_pin='x.x') }}
@@ -186,8 +186,8 @@ outputs:
   - name: libtorch
   - name: pytorch
     build:
-      string: cuda{{ cuda_compiler_version | replace('.', '') }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
-      string: cpu_{{ blas_impl }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                 # [cuda_compiler_version == "None"]
+      string: cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}_h{{ PKG_HASH }}_{{ build }}  # [cuda_compiler_version != "None"]
+      string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ build }}                                                 # [cuda_compiler_version == "None"]
       detect_binary_files_with_prefix: false
       run_exports:
         - {{ pin_subpackage('pytorch', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2.4.1" %}
-{% set build = 5 %}
+{% set build = 6 %}
 
 {% if cuda_compiler_version != "None" %}
 {% set build = build + 200 %}
@@ -353,7 +353,9 @@ outputs:
         - pytorch-cpu                                      # [cuda_compiler_version == "None"]
     requirements:
       run:
-        - {{ pin_subpackage("pytorch", exact=True) }}
+        - pytorch {{ version }}=cuda*_{{ blas_impl }}*{{ PKG_BUILDNUM }}  # [megabuild and cuda_compiler_version != "None"]
+        - pytorch {{ version }}=cpu_{{ blas_impl }}*{{ PKG_BUILDNUM }}    # [megabuild and cuda_compiler_version == "None"]
+        - {{ pin_subpackage("pytorch", exact=True) }}                     # [not megabuild]
     test:
       imports:
         - torch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -118,6 +118,7 @@ requirements:
     {% if cuda_major >= 12 %}
     - cuda-driver-dev
     - cuda-cudart-dev
+    - cuda-cupti-dev
     - cuda-nvrtc-dev
     - cuda-nvtx-dev
     - cuda-nvml-dev
@@ -239,6 +240,7 @@ outputs:
         {% if cuda_major >= 12 %}
         - cuda-driver-dev
         - cuda-cudart-dev
+        - cuda-cupti-dev
         - cuda-nvrtc-dev
         - cuda-nvtx-dev
         - cuda-nvml-dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,8 +51,8 @@ source:
 
 build:
   number: {{ build }}
-  string: cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}_h{{ PKG_HASH }}_{{ build }}  # [cuda_compiler_version != "None"]
-  string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ build }}                                                 # [cuda_compiler_version == "None"]
+  string: cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
+  string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                 # [cuda_compiler_version == "None"]
   detect_binary_files_with_prefix: false
   run_exports:
     - {{ pin_subpackage('libtorch', max_pin='x.x') }}
@@ -186,8 +186,8 @@ outputs:
   - name: libtorch
   - name: pytorch
     build:
-      string: cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}_h{{ PKG_HASH }}_{{ build }}  # [cuda_compiler_version != "None"]
-      string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ build }}                                                 # [cuda_compiler_version == "None"]
+      string: cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}_py{{ CONDA_PY }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
+      string: cpu_{{ blas_impl }}_py{{ CONDA_PY }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                 # [cuda_compiler_version == "None"]
       detect_binary_files_with_prefix: false
       run_exports:
         - {{ pin_subpackage('pytorch', max_pin='x.x') }}
@@ -345,8 +345,8 @@ outputs:
   {% set pytorch_cpu_gpu = "pytorch-gpu" %}   # [cuda_compiler_version != "None"]
   - name: {{ pytorch_cpu_gpu }}
     build:
-      string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
-      string: cpu_{{ blas_impl }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                      # [cuda_compiler_version == "None"]
+      string: cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}py{{ CONDA_PY }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
+      string: cpu_{{ blas_impl }}_py{{ CONDA_PY }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [cuda_compiler_version == "None"]
       detect_binary_files_with_prefix: false
       skip: true  # [cuda_compiler_version != "None" and linux64 and blas_impl != "mkl"]
       # weigh down cpu implementation and give cuda preference

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,6 +86,7 @@ requirements:
     {% if cuda_major >= 12 %}
     - cuda-driver-dev                        # [build_platform != target_platform]
     - cuda-cudart-dev                        # [build_platform != target_platform]
+    - cuda-cupti-dev                         # [build_platform != target_platform]
     - cuda-nvrtc-dev                         # [build_platform != target_platform]
     - cuda-nvtx-dev                          # [build_platform != target_platform]
     - cuda-nvml-dev                          # [build_platform != target_platform]
@@ -208,6 +209,7 @@ outputs:
         {% if cuda_major >= 12 %}
         - cuda-driver-dev                        # [build_platform != target_platform]
         - cuda-cudart-dev                        # [build_platform != target_platform]
+        - cuda-cupti-dev                         # [build_platform != target_platform]
         - cuda-nvrtc-dev                         # [build_platform != target_platform]
         - cuda-nvtx-dev                          # [build_platform != target_platform]
         - cuda-nvml-dev                          # [build_platform != target_platform]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,8 +101,7 @@ requirements:
     - m2-patch  # [win]
     - git       # [not win]
     - m2-git    # [win]
-    - libgomp   # [linux]
-    - llvm-openmp    # [osx]
+    - llvm-openmp    # [not win]
     - cmake
     - ninja
     # Keep libprotobuf here so that a compatibile version
@@ -144,8 +143,7 @@ requirements:
     - libcblas * *_mkl      # [blas_impl == "mkl"]
     - libcblas              # [blas_impl != "mkl"]
     - liblapack             # [blas_impl != "mkl"]
-    - libgomp   # [linux]
-    - llvm-openmp    # [osx]
+    - llvm-openmp           # [not win]
     - libabseil
     - libprotobuf
     - sleef
@@ -224,8 +222,7 @@ outputs:
         - m2-patch  # [win]
         - git       # [not win]
         - m2-git    # [win]
-        - libgomp   # [linux]
-        - llvm-openmp    # [osx]
+        - llvm-openmp    # [not win]
         - cmake
         - ninja
         # Keep libprotobuf here so that a compatibile version
@@ -265,8 +262,7 @@ outputs:
         - libcblas * *_mkl      # [blas_impl == "mkl"]
         - libcblas              # [blas_impl != "mkl"]
         - liblapack             # [blas_impl != "mkl"]
-        - libgomp   # [linux]
-        - llvm-openmp    # [osx]
+        - llvm-openmp           # [not win]
         - libabseil
         - libprotobuf
         - sleef
@@ -276,7 +272,7 @@ outputs:
         - typing_extensions
         - {{ pin_subpackage('libtorch', exact=True) }}
       run:
-        - llvm-openmp    # [osx]
+        - llvm-openmp    # [not win]
         # GPU requirements without run_exports
         - {{ pin_compatible('cudnn') }}                       # [cuda_compiler_version != "None"]
         # other requirements

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,7 @@ source:
     - patches/0006-Allow-users-to-overwrite-ld-with-environment-variabl.patch
 
     - patches/0007-Fix-duplicate-linker-script.patch  # [cuda_compiler_version != "None" and aarch64]
+    - patches/0008-Fix-CUPTI-lookup-to-include-target-directory.patch
 
 build:
   number: {{ build }}

--- a/recipe/patches/0008-Fix-CUPTI-lookup-to-include-target-directory.patch
+++ b/recipe/patches/0008-Fix-CUPTI-lookup-to-include-target-directory.patch
@@ -1,0 +1,29 @@
+From 559073f84ee8ca6041534850815a77bc39260aa6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
+Date: Thu, 6 Mar 2025 13:57:25 +0100
+Subject: [PATCH 16/16] Fix CUPTI lookup to include target directory
+
+---
+ cmake/Dependencies.cmake | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
+index b94993c34..aa4d8baf6 100644
+--- a/cmake/Dependencies.cmake
++++ b/cmake/Dependencies.cmake
+@@ -1602,6 +1602,7 @@ if(USE_KINETO)
+     endif()
+ 
+     find_library(CUPTI_LIBRARY_PATH ${CUPTI_LIB_NAME} PATHS
++        ${CUDAToolkit_TARGET_DIR}/lib
+         ${CUDA_SOURCE_DIR}
+         ${CUDA_SOURCE_DIR}/extras/CUPTI/lib64
+         ${CUDA_SOURCE_DIR}/lib
+@@ -1609,6 +1610,7 @@ if(USE_KINETO)
+         NO_DEFAULT_PATH)
+ 
+     find_path(CUPTI_INCLUDE_DIR cupti.h PATHS
++        ${CUDAToolkit_TARGET_DIR}/include
+         ${CUDA_SOURCE_DIR}/extras/CUPTI/include
+         ${CUDA_INCLUDE_DIRS}
+         ${CUDA_SOURCE_DIR}

--- a/recipe/patches/0008-Fix-CUPTI-lookup-to-include-target-directory.patch
+++ b/recipe/patches/0008-Fix-CUPTI-lookup-to-include-target-directory.patch
@@ -19,7 +19,7 @@ index c4661e39e..355a5c40f 100644
 +        )
  
      find_path(CUPTI_INCLUDE_DIR cupti.h PATHS
-+        ${CUDAToolkit_TARGET_DIR}/include:
++        ${CUDAToolkit_TARGET_DIR}/include
          ${CUDA_SOURCE_DIR}/extras/CUPTI/include
          ${CUDA_INCLUDE_DIRS}
          ${CUDA_SOURCE_DIR}

--- a/recipe/patches/0008-Fix-CUPTI-lookup-to-include-target-directory.patch
+++ b/recipe/patches/0008-Fix-CUPTI-lookup-to-include-target-directory.patch
@@ -1,29 +1,25 @@
-From 559073f84ee8ca6041534850815a77bc39260aa6 Mon Sep 17 00:00:00 2001
+From 81de6b92a50ed43323f54e769f1b7c0661ebfb0e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
-Date: Thu, 6 Mar 2025 13:57:25 +0100
-Subject: [PATCH 16/16] Fix CUPTI lookup to include target directory
+Date: Mon, 17 Mar 2025 15:03:30 +0100
+Subject: [PATCH] Fix CUPTI lookup to include target directory
 
 ---
- cmake/Dependencies.cmake | 2 ++
- 1 file changed, 2 insertions(+)
+ cmake/Dependencies.cmake | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
-index b94993c34..aa4d8baf6 100644
+index c4661e39e..355a5c40f 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
-@@ -1602,6 +1602,7 @@ if(USE_KINETO)
-     endif()
- 
-     find_library(CUPTI_LIBRARY_PATH ${CUPTI_LIB_NAME} PATHS
-+        ${CUDAToolkit_TARGET_DIR}/lib
-         ${CUDA_SOURCE_DIR}
+@@ -1605,9 +1605,10 @@ if(USE_KINETO)
          ${CUDA_SOURCE_DIR}/extras/CUPTI/lib64
          ${CUDA_SOURCE_DIR}/lib
-@@ -1609,6 +1610,7 @@ if(USE_KINETO)
-         NO_DEFAULT_PATH)
+         ${CUDA_SOURCE_DIR}/lib64
+-        NO_DEFAULT_PATH)
++        )
  
      find_path(CUPTI_INCLUDE_DIR cupti.h PATHS
-+        ${CUDAToolkit_TARGET_DIR}/include
++        ${CUDAToolkit_TARGET_DIR}/include:
          ${CUDA_SOURCE_DIR}/extras/CUPTI/include
          ${CUDA_INCLUDE_DIRS}
          ${CUDA_SOURCE_DIR}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is a fork of #341, on top of which I attempted enabling Kineto with CUPTI. Unfortunately, I couldn't get it to work — possibly it needs more CUDA lookup fixes from 2.5.x. But that's too much for my feverish brain right now. Still, opening a draft in case anyone wanted to try some more.