### PR TITLE
Let pytorch depend on libtorch with same build number again

### DIFF
--- a/.ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
@@ -38,12 +38,14 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 magma:
-- 2.9.0
+- '2.9'
 megabuild:
 - 'true'
 mkl:
@@ -69,7 +71,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
@@ -38,12 +38,14 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 magma:
-- 2.9.0
+- '2.9'
 megabuild:
 - 'true'
 mkl:
@@ -69,7 +71,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implmklc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
@@ -38,12 +38,14 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 magma:
-- 2.9.0
+- '2.9'
 megabuild:
 - 'true'
 mkl:
@@ -69,7 +71,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implmklc_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
@@ -38,12 +38,14 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 magma:
-- 2.9.0
+- '2.9'
 megabuild:
 - 'true'
 mkl:
@@ -69,7 +71,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_c_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
@@ -38,12 +38,14 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 magma:
-- 2.9.0
+- '2.9'
 megabuild:
 - 'true'
 mkl:
@@ -69,7 +71,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_c_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
@@ -38,12 +38,14 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 magma:
-- 2.9.0
+- '2.9'
 megabuild:
 - 'true'
 mkl:
@@ -69,7 +71,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/migrations/magma.yaml
+++ b/.ci_support/migrations/magma.yaml
@@ -1,0 +1,12 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for magma 2.9
+  kind: version
+  migration_number: 1
+magma:
+- '2.9'
+libmagma:
+- '2.9'
+libmagma_sparse:
+- '2.9'
+migrator_ts: 1744083773.2525206

--- a/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.10.____cpython.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.11.____cpython.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.12.____cpython.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.9.____cpython.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalsenumpy2python3.13.____cp313.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.10.____cpython.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.11.____cpython.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.12.____cpython.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.9.____cpython.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalsenumpy2python3.13.____cp313.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.10.____cpython.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.11.____cpython.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.12.____cpython.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2.0python3.9.____cpython.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalsenumpy2python3.13.____cp313.yaml
@@ -34,10 +34,12 @@ libcblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 llvm_openmp:
 - '18'
 macos_machine:
@@ -57,7 +59,7 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/win_64_channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNoneis_rcFalse.yaml
+++ b/.ci_support/win_64_channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNoneis_rcFalse.yaml
@@ -22,12 +22,14 @@ is_rc:
 - 'False'
 libabseil:
 - '20250127'
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 magma:
-- 2.9.0
+- '2.9'
 megabuild:
 - 'true'
 mkl:
@@ -51,7 +53,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - win-64
 zip_keys:

--- a/.ci_support/win_64_channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6is_rcFalse.yaml
+++ b/.ci_support/win_64_channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6is_rcFalse.yaml
@@ -22,12 +22,14 @@ is_rc:
 - 'False'
 libabseil:
 - '20250127'
+libmagma_sparse:
+- '2.9'
 libprotobuf:
 - 5.29.3
 libtorch:
-- '2.5'
+- '2.6'
 magma:
-- 2.9.0
+- '2.9'
 megabuild:
 - 'true'
 mkl:
@@ -51,7 +53,7 @@ python:
 - 3.13.* *_cp313
 - 3.9.* *_cpython
 pytorch:
-- '2.5'
+- '2.6'
 target_platform:
 - win-64
 zip_keys:

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -15,9 +15,6 @@ zip_keys:
     - channel_targets
     - is_rc
 
-magma:
-  - 2.9.0
-
 blas_impl:
   - mkl                         # [x86_64]
   # deprioritized on windows, would be nice to have

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -183,10 +183,10 @@ requirements:
     # pytorch-cpu 1.1 which we built before conda-forge had GPU infrastructure
     # built into place.
     # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/65
-    - pytorch-cpu =={{ version }}  # [cuda_compiler_version == "None"]
-    - pytorch-gpu ==99999999       # [cuda_compiler_version == "None"]
-    - pytorch-gpu =={{ version }}  # [cuda_compiler_version != "None"]
-    - pytorch-cpu ==99999999       # [cuda_compiler_version != "None"]
+    - pytorch-cpu {{ version }}    # [cuda_compiler_version == "None"]
+    - pytorch-gpu <0.0a0           # [cuda_compiler_version == "None"]
+    - pytorch-gpu {{ version }}    # [cuda_compiler_version != "None"]
+    - pytorch-cpu <0.0a0           # [cuda_compiler_version != "None"]
     - pytorch {{ version }} cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}_*_{{ build }}  # [cuda_compiler_version != "None"]
     - pytorch {{ version }} cpu_{{ blas_impl }}_*_{{ build }}                                                 # [cuda_compiler_version == "None"]
     # if using OpenBLAS, ensure that a version compatible with OpenMP is used
@@ -356,10 +356,10 @@ outputs:
         # pytorch-cpu 1.1 which we built before conda-forge had GPU infrastructure
         # built into place.
         # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/65
-        - pytorch-cpu =={{ version }}  # [cuda_compiler_version == "None"]
-        - pytorch-gpu ==99999999       # [cuda_compiler_version == "None"]
-        - pytorch-gpu =={{ version }}  # [cuda_compiler_version != "None"]
-        - pytorch-cpu ==99999999       # [cuda_compiler_version != "None"]
+        - pytorch-cpu {{ version }}    # [cuda_compiler_version == "None"]
+        - pytorch-gpu <0.0a0           # [cuda_compiler_version == "None"]
+        - pytorch-gpu {{ version }}    # [cuda_compiler_version != "None"]
+        - pytorch-cpu <0.0a0           # [cuda_compiler_version != "None"]
 
     test:
       requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -534,10 +534,9 @@ outputs:
   {% set pytorch_cpu_gpu = "pytorch-gpu" %}   # [cuda_compiler_version != "None"]
   - name: {{ pytorch_cpu_gpu }}
     build:
-      string: cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}_h{{ PKG_HASH }}_{{ build }}                  # [megabuild and cuda_compiler_version != "None"]
-      string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ build }}                                                                 # [megabuild and cuda_compiler_version == "None"]
-      string: cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}py{{ CONDA_PY }}_h{{ PKG_HASH }}_{{ build }}  # [not megabuild and cuda_compiler_version != "None"]
-      string: cpu_{{ blas_impl }}_py{{ CONDA_PY }}_h{{ PKG_HASH }}_{{ build }}                                                # [not megabuild and cuda_compiler_version == "None"]
+      string: cuda{{ cuda_compiler_version | replace('.', '') }}_{{ blas_impl }}_h{{ PKG_HASH }}_{{ build }}    # [megabuild and cuda_compiler_version != "None"]
+      string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ build }}                                                   # [megabuild and cuda_compiler_version == "None"]
+      string: cpu_{{ blas_impl }}_py{{ CONDA_PY }}_h{{ PKG_HASH }}_{{ build }}                                  # [not megabuild]
       detect_binary_files_with_prefix: false
       # weigh down cpu implementation and give cuda preference
       track_features:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -325,9 +325,8 @@ outputs:
         - zlib
       run:
         - {{ pin_subpackage('libtorch', exact=True) }}  # [megabuild]
-        # for non-megabuild, allow libtorch from any python version;
-        # pinning build number would be nice but breaks conda
-        - libtorch {{ version }}.*                      # [not megabuild]
+        # for non-megabuild, allow libtorch from any python version
+        - libtorch {{ version }}.* *_{{ build }}        # [not megabuild]
         - llvm-openmp                       # [unix]
         - intel-openmp {{ mkl }}            # [win]
         - libblas * *{{ blas_impl }}        # [blas_impl == "mkl"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # if you wish to build release candidate number X, append the version string with ".rcX"
 {% set version = "2.6.0" %}
-{% set build = 3 %}
+{% set build = 4 %}
 
 # Use a higher build number for the CUDA variant, to ensure that it's
 # preferred by conda's solver, and it's preferentially

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -544,8 +544,8 @@ outputs:
         - pytorch-cpu                                      # [cuda_compiler_version == "None"]
     requirements:
       run:
-        - pytorch {{ version }}=cuda*_{{ blas_impl }}*{{ build }}   # [megabuild and cuda_compiler_version != "None"]
-        - pytorch {{ version }}=cpu_{{ blas_impl }}*{{ build }}     # [megabuild and cuda_compiler_version == "None"]
+        - pytorch {{ version }} cuda*_{{ blas_impl }}*{{ build }}   # [megabuild and cuda_compiler_version != "None"]
+        - pytorch {{ version }} cpu_{{ blas_impl }}*{{ build }}     # [megabuild and cuda_compiler_version == "None"]
         - {{ pin_subpackage("pytorch", exact=True) }}               # [not megabuild]
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -112,7 +112,7 @@ requirements:
     - llvm-openmp               # [unix]
     - intel-openmp {{ mkl }}    # [win]
     - libuv                     # [win]
-    - cmake
+    - cmake <4
     - ninja
     # Keep libprotobuf here so that a compatibile version
     # of protobuf is installed between build and host
@@ -206,7 +206,7 @@ test:
     - {{ compiler('cuda') }}    # [cuda_compiler_version != "None"]
     - cuda-nvrtc-dev            # [cuda_compiler_version != "None"]
     - nvtx-c                    # [cuda_compiler_version != "None"]
-    - cmake
+    - cmake <4
     - ninja
     - pkg-config
   files:
@@ -266,7 +266,7 @@ outputs:
         - {{ compiler('cuda') }}                 # [cuda_compiler_version != "None"]
         - llvm-openmp             # [unix]
         - intel-openmp {{ mkl }}  # [win]
-        - cmake
+        - cmake <4
         - ninja
         # Keep libprotobuf here so that a compatibile version
         # of protobuf is installed between build and host
@@ -385,7 +385,7 @@ outputs:
         # https://github.com/pytorch/pytorch/blob/main/test/pytest_shard_custom.py
         # - pytest-shard
         # for cmake_test
-        - cmake
+        - cmake <4
         - cuda-nvrtc-dev            # [cuda_compiler_version != "None"]
         - nvtx-c                    # [cuda_compiler_version != "None"]
         - pybind11


### PR DESCRIPTION
I'm hoping that conda-build 25.3 fixes this, c.f. for example https://github.com/conda-forge/conda-smithy/issues/2262

Closes #384