### PR TITLE
Fix missing symbols of pytorch_python on Windows & magma 2.9

### DIFF
--- a/.ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
@@ -42,6 +42,8 @@ libprotobuf:
 - 5.29.3
 libtorch:
 - '2.5'
+magma:
+- 2.9.0
 megabuild:
 - 'true'
 mkl:

--- a/.ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
@@ -42,6 +42,8 @@ libprotobuf:
 - 5.29.3
 libtorch:
 - '2.5'
+magma:
+- 2.9.0
 megabuild:
 - 'true'
 mkl:

--- a/.ci_support/linux_64_blas_implmklc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
@@ -42,6 +42,8 @@ libprotobuf:
 - 5.29.3
 libtorch:
 - '2.5'
+magma:
+- 2.9.0
 megabuild:
 - 'true'
 mkl:

--- a/.ci_support/linux_64_blas_implmklc_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implmklc_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
@@ -42,6 +42,8 @@ libprotobuf:
 - 5.29.3
 libtorch:
 - '2.5'
+magma:
+- 2.9.0
 megabuild:
 - 'true'
 mkl:

--- a/.ci_support/linux_aarch64_c_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13is_rcFalse.yaml
@@ -42,6 +42,8 @@ libprotobuf:
 - 5.29.3
 libtorch:
 - '2.5'
+magma:
+- 2.9.0
 megabuild:
 - 'true'
 mkl:

--- a/.ci_support/linux_aarch64_c_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13is_rcFalse.yaml
@@ -42,6 +42,8 @@ libprotobuf:
 - 5.29.3
 libtorch:
 - '2.5'
+magma:
+- 2.9.0
 megabuild:
 - 'true'
 mkl:

--- a/.ci_support/win_64_channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNoneis_rcFalse.yaml
+++ b/.ci_support/win_64_channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNoneis_rcFalse.yaml
@@ -26,6 +26,8 @@ libprotobuf:
 - 5.29.3
 libtorch:
 - '2.5'
+magma:
+- 2.9.0
 megabuild:
 - 'true'
 mkl:

--- a/.ci_support/win_64_channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6is_rcFalse.yaml
+++ b/.ci_support/win_64_channel_targetsconda-forge_maincuda_compilercuda-nvcccuda_compiler_version12.6is_rcFalse.yaml
@@ -26,6 +26,8 @@ libprotobuf:
 - 5.29.3
 libtorch:
 - '2.5'
+magma:
+- 2.9.0
 megabuild:
 - 'true'
 mkl:

--- a/recipe/cmake_test/CMakeLists.txt
+++ b/recipe/cmake_test/CMakeLists.txt
@@ -1,29 +1,42 @@
 project(cf_dummy LANGUAGES C CXX)
 cmake_minimum_required(VERSION 3.12)
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
-find_package(pybind11 CONFIG REQUIRED)
+
 find_package(Torch CONFIG REQUIRED)
 find_package(ATen CONFIG REQUIRED)
-if(WIN32)
-  set(libtorch_base_path $ENV{PREFIX}/Lib/site-packages/torch)
-else()
-  set(libtorch_base_path $ENV{PREFIX})
+
+option(WITH_TORCH_PYTHON "Build with torch_python" OFF)
+
+if(WITH_TORCH_PYTHON)
+  if(WIN32)
+    set(libtorch_base_path $ENV{PREFIX}/Lib/site-packages/torch)
+  else()
+    set(libtorch_base_path $ENV{PREFIX})
+  endif()
+  find_library(torch_python NAMES torch_python HINTS ${libtorch_base_path}/lib/ REQUIRED)
+
+  find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+  find_package(pybind11 CONFIG REQUIRED)
+
+  add_executable(cmake_test main.cpp)
+
+  target_include_directories(cmake_test PRIVATE
+    ${ATEN_INCLUDE_DIR}
+    ${TORCH_INCLUDE_DIRS}
+    ${Python3_INCLUDE_DIRS}
+  )
+
+  target_link_libraries(cmake_test PRIVATE
+    ${ATEN_LIBRARIES}
+    ${TORCH_LIBRARIES}
+    pybind11::pybind11
+    Python3::Python
+  )
+
+  target_link_libraries(cmake_test PRIVATE
+    ${torch_python}
+  )
+
+  target_compile_options(cmake_test PRIVATE
+    ${TORCH_CXX_FLAGS}
+  )
 endif()
-find_library(torch_python NAMES torch_python HINTS ${libtorch_base_path}/lib/ REQUIRED)
-set(target_name cmake_test)
-add_executable(${target_name} main.cpp)
-target_include_directories(${target_name} PRIVATE
-  ${ATEN_INCLUDE_DIR}
-  ${TORCH_INCLUDE_DIRS}
-  ${Python3_INCLUDE_DIRS}
-)
-target_link_libraries(${target_name} PRIVATE
-  ${ATEN_LIBRARIES}
-  ${TORCH_LIBRARIES}
-  ${torch_python}
-  pybind11::pybind11
-  Python3::Python
-)
-target_compile_options(${target_name} PRIVATE
-  ${TORCH_CXX_FLAGS}
-)

--- a/recipe/cmake_test/CMakeLists.txt
+++ b/recipe/cmake_test/CMakeLists.txt
@@ -1,4 +1,29 @@
 project(cf_dummy LANGUAGES C CXX)
 cmake_minimum_required(VERSION 3.12)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(pybind11 CONFIG REQUIRED)
 find_package(Torch CONFIG REQUIRED)
 find_package(ATen CONFIG REQUIRED)
+if(WIN32)
+  set(libtorch_base_path $ENV{PREFIX}/Lib/site-packages/torch)
+else()
+  set(libtorch_base_path $ENV{PREFIX})
+endif()
+find_library(torch_python NAMES torch_python HINTS ${libtorch_base_path}/lib/ REQUIRED)
+set(target_name cmake_test)
+add_executable(${target_name} main.cpp)
+target_include_directories(${target_name} PRIVATE
+  ${ATEN_INCLUDE_DIR}
+  ${TORCH_INCLUDE_DIRS}
+  ${Python3_INCLUDE_DIRS}
+)
+target_link_libraries(${target_name} PRIVATE
+  ${ATEN_LIBRARIES}
+  ${TORCH_LIBRARIES}
+  ${torch_python}
+  pybind11::pybind11
+  Python3::Python
+)
+target_compile_options(${target_name} PRIVATE
+  ${TORCH_CXX_FLAGS}
+)

--- a/recipe/cmake_test/main.cpp
+++ b/recipe/cmake_test/main.cpp
@@ -1,0 +1,9 @@
+#include <torch/csrc/jit/python/python_ivalue.h>
+
+int main() {
+  using torch::autograd::variable_list;
+  auto vl = variable_list();
+  (void)vl;
+
+  return 0;
+}

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -15,6 +15,9 @@ zip_keys:
     - channel_targets
     - is_rc
 
+magma:
+  - 2.9.0
+
 blas_impl:
   - mkl                         # [x86_64]
   # deprioritized on windows, would be nice to have

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -152,7 +152,8 @@ requirements:
     - numpy *      # [megabuild]
     - numpy        # [not megabuild]
     - pip
-    - setuptools
+    # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/380
+    - setuptools <76
     - pyyaml
     - requests
     - six
@@ -302,7 +303,8 @@ outputs:
         - python
         - numpy
         - pip
-        - setuptools
+        # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/380
+        - setuptools <76
         - pyyaml
         - requests
         - six
@@ -343,7 +345,9 @@ outputs:
         - networkx
         - optree >=0.13.0
         - pybind11
-        - setuptools
+        # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/380; also used at runtime, see
+        # https://github.com/pytorch/pytorch/blob/v2.6.0/torch/utils/cpp_extension.py#L2166-2172
+        - setuptools <76
         # sympy 1.13.2 was reported to result in test failures on Windows and mac
         # https://github.com/pytorch/pytorch/pull/133235
         - sympy >=1.13.1,!=1.13.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # if you wish to build release candidate number X, append the version string with ".rcX"
 {% set version = "2.6.0" %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 # Use a higher build number for the CUDA variant, to ensure that it's
 # preferred by conda's solver, and it's preferentially
@@ -61,6 +61,7 @@ source:
     # backport https://github.com/pytorch/pytorch/pull/140030
     - patches/0015-export-AOTI_TORCH_EXPORT-on-Windows.-140030.patch
     - patches/0016-Fix-CUPTI-lookup-to-include-target-directory.patch
+    - patches/0017-Hide-torch_python-symbols-142214.patch
     - patches_submodules/fbgemm/0001-remove-DESTINATION-lib-from-CMake-install-directives.patch     # [win]
     - patches_submodules/tensorpipe/0001-switch-away-from-find_package-CUDA.patch
     # backport https://github.com/google/XNNPACK/commit/5f23827e66cca435fa400b6e221892ac95af0079
@@ -202,9 +203,11 @@ test:
     # for CMake config to find cuda & nvrtc
     - {{ compiler('cuda') }}    # [cuda_compiler_version != "None"]
     - cuda-nvrtc-dev            # [cuda_compiler_version != "None"]
+    - cuda-nvtx-dev             # [cuda_compiler_version != "None"]
     - cmake
     - ninja
     - pkg-config
+    - pybind11
   files:
     - cmake_test/
   commands:
@@ -378,9 +381,15 @@ outputs:
         # it into the test deps as well results in the --shard-id option being added twice.
         # https://github.com/pytorch/pytorch/blob/main/test/pytest_shard_custom.py
         # - pytest-shard
+        # for cmake_test
+        - cmake
+        - cuda-nvrtc-dev            # [cuda_compiler_version != "None"]
+        - pybind11
       imports:
         - torch
         - torch._C
+      files:
+        - cmake_test/
       source_files:
         # Only include the source_files if we are actually going to run the tests.
         - test
@@ -506,6 +515,13 @@ outputs:
         # obviously this test can only be done for other python versions.
         - test ! -f $SP_DIR/functorch/__pycache__/__init__.cpython-313.pyc          # [py!=313 and unix]
         - if exist %SP_DIR%\functorch\__pycache__\__init__.cpython-313.pyc exit 1   # [py!=313 and win]
+
+        # test integrity of CMake metadata and ensure that THPLayoutType is visible as a symbol from libtorch_python
+        - cd cmake_test
+        - cmake -GNinja -DCMAKE_CXX_STANDARD=17 $CMAKE_ARGS .   # [unix]
+        - cmake -GNinja -DCMAKE_CXX_STANDARD=17 %CMAKE_ARGS% .  # [win]
+        - cmake --build .                   # [unix]
+        - cmake --build . --config Release  # [win]
 
   # 2021/08/01, hmaarrfk
   # While this seems like a roundabout way of defining the package name

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,6 +62,7 @@ source:
     - patches/0015-export-AOTI_TORCH_EXPORT-on-Windows.-140030.patch
     - patches/0016-Fix-CUPTI-lookup-to-include-target-directory.patch
     - patches/0017-Hide-torch_python-symbols-142214.patch
+    - patches/0018-Always-use-system-nvtx.patch
     - patches_submodules/fbgemm/0001-remove-DESTINATION-lib-from-CMake-install-directives.patch     # [win]
     - patches_submodules/tensorpipe/0001-switch-away-from-find_package-CUDA.patch
     # backport https://github.com/google/XNNPACK/commit/5f23827e66cca435fa400b6e221892ac95af0079
@@ -203,7 +204,7 @@ test:
     # for CMake config to find cuda & nvrtc
     - {{ compiler('cuda') }}    # [cuda_compiler_version != "None"]
     - cuda-nvrtc-dev            # [cuda_compiler_version != "None"]
-    - cuda-nvtx-dev             # [cuda_compiler_version != "None"]
+    - nvtx-c                    # [cuda_compiler_version != "None"]
     - cmake
     - ninja
     - pkg-config
@@ -383,6 +384,7 @@ outputs:
         # for cmake_test
         - cmake
         - cuda-nvrtc-dev            # [cuda_compiler_version != "None"]
+        - nvtx-c                    # [cuda_compiler_version != "None"]
         - pybind11
       imports:
         - torch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -207,7 +207,6 @@ test:
     - cmake
     - ninja
     - pkg-config
-    - pybind11
   files:
     - cmake_test/
   commands:
@@ -518,8 +517,8 @@ outputs:
 
         # test integrity of CMake metadata and ensure that THPLayoutType is visible as a symbol from libtorch_python
         - cd cmake_test
-        - cmake -GNinja -DCMAKE_CXX_STANDARD=17 $CMAKE_ARGS .   # [unix]
-        - cmake -GNinja -DCMAKE_CXX_STANDARD=17 %CMAKE_ARGS% .  # [win]
+        - cmake -GNinja -DCMAKE_CXX_STANDARD=17 -DWITH_TORCH_PYTHON=ON $CMAKE_ARGS .   # [unix]
+        - cmake -GNinja -DCMAKE_CXX_STANDARD=17 -DWITH_TORCH_PYTHON=ON %CMAKE_ARGS% .  # [win]
         - cmake --build .                   # [unix]
         - cmake --build . --config Release  # [win]
 

--- a/recipe/patches/0017-Hide-torch_python-symbols-142214.patch
+++ b/recipe/patches/0017-Hide-torch_python-symbols-142214.patch
@@ -1,0 +1,268 @@
+From 17865a4af5ca2e97a168b61f881a11cb16780230 Mon Sep 17 00:00:00 2001
+From: cyy <cyyever@outlook.com>
+Date: Mon, 16 Dec 2024 00:59:26 +0000
+Subject: [PATCH] Hide torch_python symbols (#142214)
+
+Change symbols in torch_python to invisible by default on platforms other than Apple.
+Pull Request resolved: https://github.com/pytorch/pytorch/pull/142214
+Approved by: https://github.com/ezyang
+---
+ torch/CMakeLists.txt                         | 2 +-
+ torch/csrc/Layout.h                          | 4 ++--
+ torch/csrc/MemoryFormat.h                    | 3 ++-
+ torch/csrc/Module.cpp                        | 3 ++-
+ torch/csrc/QScheme.h                         | 3 ++-
+ torch/csrc/Size.h                            | 3 ++-
+ torch/csrc/Storage.h                         | 4 ++--
+ torch/csrc/TypeInfo.h                        | 5 +++--
+ torch/csrc/autograd/python_function.h        | 7 ++++---
+ torch/csrc/lazy/ts_backend/ts_backend_impl.h | 2 +-
+ torch/csrc/tensor/python_tensor.h            | 7 ++++---
+ torch/csrc/utils/device_lazy_init.h          | 3 ++-
+ 12 files changed, 27 insertions(+), 19 deletions(-)
+
+diff --git a/torch/CMakeLists.txt b/torch/CMakeLists.txt
+index 650319cb1ee..aebd0d1f442 100644
+--- a/torch/CMakeLists.txt
++++ b/torch/CMakeLists.txt
+@@ -310,7 +310,7 @@ endif()
+ 
+ add_library(torch_python SHARED ${TORCH_PYTHON_SRCS})
+ torch_compile_options(torch_python)  # see cmake/public/utils.cmake
+-if(NOT WIN32)
++if(APPLE)
+   target_compile_options(torch_python PRIVATE
+       $<$<COMPILE_LANGUAGE:CXX>: -fvisibility=default>)
+ endif()
+diff --git a/torch/csrc/Layout.h b/torch/csrc/Layout.h
+index 3b6844c9bad..a6864094df9 100644
+--- a/torch/csrc/Layout.h
++++ b/torch/csrc/Layout.h
+@@ -1,5 +1,5 @@
+ #pragma once
+-
++#include <torch/csrc/Export.h>
+ #include <torch/csrc/python_headers.h>
+ 
+ #include <ATen/Layout.h>
+@@ -15,7 +15,7 @@ struct THPLayout {
+   char name[LAYOUT_NAME_LEN + 1];
+ };
+ 
+-extern PyTypeObject THPLayoutType;
++TORCH_PYTHON_API extern PyTypeObject THPLayoutType;
+ 
+ inline bool THPLayout_Check(PyObject* obj) {
+   return Py_TYPE(obj) == &THPLayoutType;
+diff --git a/torch/csrc/MemoryFormat.h b/torch/csrc/MemoryFormat.h
+index 566270e70ab..c539564b1b8 100644
+--- a/torch/csrc/MemoryFormat.h
++++ b/torch/csrc/MemoryFormat.h
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <torch/csrc/Export.h>
+ #include <torch/csrc/python_headers.h>
+ 
+ #include <c10/core/MemoryFormat.h>
+@@ -15,7 +16,7 @@ struct THPMemoryFormat {
+   char name[MEMORY_FORMAT_NAME_LEN + 1];
+ };
+ 
+-extern PyTypeObject THPMemoryFormatType;
++TORCH_PYTHON_API extern PyTypeObject THPMemoryFormatType;
+ 
+ inline bool THPMemoryFormat_Check(PyObject* obj) {
+   return Py_TYPE(obj) == &THPMemoryFormatType;
+diff --git a/torch/csrc/Module.cpp b/torch/csrc/Module.cpp
+index 2182cd84cf1..4b083fb7bde 100644
+--- a/torch/csrc/Module.cpp
++++ b/torch/csrc/Module.cpp
+@@ -46,6 +46,7 @@
+ #include <torch/csrc/Dtype.h>
+ #include <torch/csrc/DynamicTypes.h>
+ #include <torch/csrc/Event.h>
++#include <torch/csrc/Export.h>
+ #include <torch/csrc/Generator.h>
+ #include <torch/csrc/Layout.h>
+ #include <torch/csrc/MemoryFormat.h>
+@@ -1717,7 +1718,7 @@ class WeakTensorRef {
+   }
+ };
+ 
+-extern "C" C10_EXPORT PyObject* initModule();
++extern "C" TORCH_PYTHON_API PyObject* initModule();
+ // separate decl and defn for msvc error C2491
+ PyObject* initModule() {
+   HANDLE_TH_ERRORS
+diff --git a/torch/csrc/QScheme.h b/torch/csrc/QScheme.h
+index f604772fb82..af8f6452032 100644
+--- a/torch/csrc/QScheme.h
++++ b/torch/csrc/QScheme.h
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <torch/csrc/Export.h>
+ #include <torch/csrc/python_headers.h>
+ 
+ #include <c10/core/QScheme.h>
+@@ -15,7 +16,7 @@ struct THPQScheme {
+   char name[QSCHEME_NAME_LEN + 1];
+ };
+ 
+-extern PyTypeObject THPQSchemeType;
++TORCH_PYTHON_API extern PyTypeObject THPQSchemeType;
+ 
+ inline bool THPQScheme_Check(PyObject* obj) {
+   return Py_TYPE(obj) == &THPQSchemeType;
+diff --git a/torch/csrc/Size.h b/torch/csrc/Size.h
+index dd4283f7d77..1f4ec4dace3 100644
+--- a/torch/csrc/Size.h
++++ b/torch/csrc/Size.h
+@@ -1,10 +1,11 @@
+ #pragma once
+ 
++#include <torch/csrc/Export.h>
+ #include <torch/csrc/autograd/variable.h>
+ #include <torch/csrc/python_headers.h>
+ #include <cstdint>
+ 
+-extern PyTypeObject THPSizeType;
++TORCH_PYTHON_API extern PyTypeObject THPSizeType;
+ 
+ #define THPSize_Check(obj) (Py_TYPE(obj) == &THPSizeType)
+ 
+diff --git a/torch/csrc/Storage.h b/torch/csrc/Storage.h
+index fc63d14ab93..36314171fac 100644
+--- a/torch/csrc/Storage.h
++++ b/torch/csrc/Storage.h
+@@ -21,7 +21,7 @@ TORCH_PYTHON_API PyObject* THPStorage_NewWithStorage(
+     c10::Storage _storage,
+     c10::impl::PyInterpreterStatus status,
+     bool allow_preexisting_pyobj = false);
+-extern PyTypeObject* THPStorageClass;
++TORCH_PYTHON_API extern PyTypeObject* THPStorageClass;
+ 
+ inline bool THPStorage_CheckTypeExact(PyTypeObject* tp) {
+   return tp == THPStorageClass;
+@@ -47,7 +47,7 @@ void THPStorage_postInit(PyObject* module);
+ void THPStorage_assertNotNull(THPStorage* storage);
+ void THPStorage_assertNotNull(PyObject* obj);
+ 
+-extern PyTypeObject THPStorageType;
++TORCH_PYTHON_API extern PyTypeObject THPStorageType;
+ 
+ inline const c10::Storage& THPStorage_Unpack(THPStorage* storage) {
+   return *storage->cdata;
+diff --git a/torch/csrc/TypeInfo.h b/torch/csrc/TypeInfo.h
+index 6841312e4a9..9eb03a49093 100644
+--- a/torch/csrc/TypeInfo.h
++++ b/torch/csrc/TypeInfo.h
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <torch/csrc/Export.h>
+ #include <torch/csrc/python_headers.h>
+ 
+ #include <ATen/ATen.h>
+@@ -13,8 +14,8 @@ struct THPFInfo : THPDTypeInfo {};
+ 
+ struct THPIInfo : THPDTypeInfo {};
+ 
+-extern PyTypeObject THPFInfoType;
+-extern PyTypeObject THPIInfoType;
++TORCH_PYTHON_API extern PyTypeObject THPFInfoType;
++TORCH_PYTHON_API extern PyTypeObject THPIInfoType;
+ 
+ inline bool THPFInfo_Check(PyObject* obj) {
+   return Py_TYPE(obj) == &THPFInfoType;
+diff --git a/torch/csrc/autograd/python_function.h b/torch/csrc/autograd/python_function.h
+index 8c4f2f68dc5..5763d5a8339 100644
+--- a/torch/csrc/autograd/python_function.h
++++ b/torch/csrc/autograd/python_function.h
+@@ -3,6 +3,7 @@
+ #include <torch/csrc/python_headers.h>
+ 
+ #include <torch/csrc/Exceptions.h>
++#include <torch/csrc/Export.h>
+ #include <torch/csrc/autograd/custom_function.h>
+ #include <torch/csrc/autograd/function.h>
+ #include <torch/csrc/autograd/saved_variable.h>
+@@ -150,9 +151,9 @@ struct THPFunction {
+ };
+ 
+ bool THPFunction_initModule(PyObject* module);
+-extern PyTypeObject THPFunctionType;
+-extern PyObject* THPFunctionClass;
+-extern PyObject* THPGradientEdgeClass;
++TORCH_PYTHON_API extern PyTypeObject THPFunctionType;
++TORCH_PYTHON_API extern PyObject* THPFunctionClass;
++TORCH_PYTHON_API extern PyObject* THPGradientEdgeClass;
+ 
+ inline bool THPFunction_Check(PyObject* obj) {
+   return PyObject_IsInstance(obj, (PyObject*)&THPFunctionType);
+diff --git a/torch/csrc/lazy/ts_backend/ts_backend_impl.h b/torch/csrc/lazy/ts_backend/ts_backend_impl.h
+index 701176c0790..a44334c54f8 100644
+--- a/torch/csrc/lazy/ts_backend/ts_backend_impl.h
++++ b/torch/csrc/lazy/ts_backend/ts_backend_impl.h
+@@ -47,6 +47,6 @@ class TORCH_API TSData : public torch::lazy::BackendData {
+ 
+ TORCH_API torch::lazy::BackendImplInterface* GetTSBackendImpl();
+ 
+-TORCH_API void InitTorchScriptBackend();
++TORCH_PYTHON_API void InitTorchScriptBackend();
+ 
+ } // namespace torch::lazy
+diff --git a/torch/csrc/tensor/python_tensor.h b/torch/csrc/tensor/python_tensor.h
+index f69ded46a04..6c2d19a2397 100644
+--- a/torch/csrc/tensor/python_tensor.h
++++ b/torch/csrc/tensor/python_tensor.h
+@@ -3,6 +3,7 @@
+ #include <c10/core/Device.h>
+ #include <c10/core/DispatchKey.h>
+ #include <c10/core/ScalarType.h>
++#include <torch/csrc/Export.h>
+ #include <torch/csrc/python_headers.h>
+ 
+ namespace at {
+@@ -13,13 +14,13 @@ namespace torch::tensors {
+ 
+ // Initializes the Python tensor type objects: torch.FloatTensor,
+ // torch.DoubleTensor, etc. and binds them in their containing modules.
+-void initialize_python_bindings();
++TORCH_PYTHON_API void initialize_python_bindings();
+ 
+ // Same as set_default_tensor_type() but takes a PyObject*
+-void py_set_default_tensor_type(PyObject* type_obj);
++TORCH_PYTHON_API void py_set_default_tensor_type(PyObject* type_obj);
+ 
+ // Same as py_set_default_tensor_type, but only changes the dtype (ScalarType).
+-void py_set_default_dtype(PyObject* dtype_obj);
++TORCH_PYTHON_API void py_set_default_dtype(PyObject* dtype_obj);
+ 
+ // Gets the DispatchKey for the default tensor type.
+ //
+diff --git a/torch/csrc/utils/device_lazy_init.h b/torch/csrc/utils/device_lazy_init.h
+index bc5f4912e2a..16fbe41bb83 100644
+--- a/torch/csrc/utils/device_lazy_init.h
++++ b/torch/csrc/utils/device_lazy_init.h
+@@ -1,6 +1,7 @@
+ #pragma once
+ 
+ #include <c10/core/TensorOptions.h>
++#include <torch/csrc/Export.h>
+ 
+ // device_lazy_init() is always compiled, even for CPU-only builds.
+ 
+@@ -23,7 +24,7 @@ namespace torch::utils {
+  * try to use CUDA or XPU functionality from a CPU-only build, which is not good
+  * UX.
+  */
+-void device_lazy_init(at::DeviceType device_type);
++TORCH_PYTHON_API void device_lazy_init(at::DeviceType device_type);
+ void set_requires_device_init(at::DeviceType device_type, bool value);
+ 
+ inline void maybe_initialize_device(at::Device& device) {
+-- 
+2.20.1.windows.1
+

--- a/recipe/patches/0017-Hide-torch_python-symbols-142214.patch
+++ b/recipe/patches/0017-Hide-torch_python-symbols-142214.patch
@@ -21,19 +21,6 @@ Approved by: https://github.com/ezyang
  torch/csrc/utils/device_lazy_init.h          | 3 ++-
  12 files changed, 27 insertions(+), 19 deletions(-)
 
-diff --git a/torch/CMakeLists.txt b/torch/CMakeLists.txt
-index 650319cb1ee..aebd0d1f442 100644
---- a/torch/CMakeLists.txt
-+++ b/torch/CMakeLists.txt
-@@ -310,7 +310,7 @@ endif()
- 
- add_library(torch_python SHARED ${TORCH_PYTHON_SRCS})
- torch_compile_options(torch_python)  # see cmake/public/utils.cmake
--if(NOT WIN32)
-+if(APPLE)
-   target_compile_options(torch_python PRIVATE
-       $<$<COMPILE_LANGUAGE:CXX>: -fvisibility=default>)
- endif()
 diff --git a/torch/csrc/Layout.h b/torch/csrc/Layout.h
 index 3b6844c9bad..a6864094df9 100644
 --- a/torch/csrc/Layout.h

--- a/recipe/patches/0018-Always-use-system-nvtx.patch
+++ b/recipe/patches/0018-Always-use-system-nvtx.patch
@@ -1,0 +1,25 @@
+From 4760a58f156522e8f02ec83befcc53bd6323ec2f Mon Sep 17 00:00:00 2001
+From: Jeongseok Lee <jeongseok@meta.com>
+Date: Sat, 22 Mar 2025 22:50:49 -0700
+Subject: [PATCH] Always use system nvtx
+
+---
+ cmake/public/cuda.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/public/cuda.cmake b/cmake/public/cuda.cmake
+index 792e2ac78d3..cb1ece22cf3 100644
+--- a/cmake/public/cuda.cmake
++++ b/cmake/public/cuda.cmake
+@@ -146,7 +146,7 @@ else()
+ endif()
+ 
+ # nvToolsExt
+-if(USE_SYSTEM_NVTX)
++if(TRUE)
+   find_path(nvtx3_dir NAMES nvtx3)
+ else()
+   find_path(nvtx3_dir NAMES nvtx3 PATHS "${PROJECT_SOURCE_DIR}/third_party/NVTX/c/include" NO_DEFAULT_PATH)
+-- 
+2.20.1.windows.1
+


### PR DESCRIPTION
Joint merge of #377 and #371, also addressing #380

Fixes #380 
Fixes #375
Fixes #357 (by ensuring USE_SYSTEM_NVTX is propagated, c.f. https://github.com/pytorch/pytorch/pull/149861)
Closes #377 
Closes #371

Would have liked to pick up #378, but that needs conda-build 25.3.1, which isn't out yet.