### PR TITLE
fix: remove track_features as they serve no purpose due to naming

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # if you wish to build release candidate number X, append the version string with ".rcX"
 {% set version = "2.7.1" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # Use a higher build number for the CUDA variant, to ensure that it's
 # preferred by conda's solver, and it's preferentially

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -539,9 +539,6 @@ outputs:
       string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ build }}                                                   # [megabuild and cuda_compiler_version == "None"]
       string: cpu_{{ blas_impl }}_py{{ CONDA_PY }}_h{{ PKG_HASH }}_{{ build }}                                  # [not megabuild]
       detect_binary_files_with_prefix: false
-      # weigh down cpu implementation and give cuda preference
-      track_features:
-        - pytorch-cpu                                      # [cuda_compiler_version == "None"]
     requirements:
       run:
         - pytorch {{ version }} cuda*_{{ blas_impl }}*{{ build }}   # [megabuild and cuda_compiler_version != "None"]


### PR DESCRIPTION
As pytorch-cpu and pytorch-gpu are now named differently so the track_features don't modify the decision making.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Since the `track_feature` is set on the `pytorch-cpu` package and not for other packages. This would make sense if the package was only named `pytorch` and you would want the solvers to prioritize the packages with or without cuda. This is not the case with the `pytorch-cpu` package. 

This would **not** have been a problem if **all** the `pytorch-cpu` version would have this flag, but that is not the case, as `pytorch-cpu 1.1.0`(and some others) do not have it. 

It would make sense to have this on the `pytorch` cpu builds, but that already works through the magic of **build numbers**.

### For example:
When installing only `pytorch-cpu` the solvers would down prioritize all the pytorch-cpu version that don't have the `track_features`. Thus resulting in an extremely old version. (Only if no other requirements/constraints are presented). 
e.g. in a empty project:
```
pixi add pytorch-cpu
✔ Added pytorch-cpu >=1.6.0,<2
```
or with `conda`:
```
conda create --dry-run -c conda-forge pytorch-cpu --platform linux-64

The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    _libgcc_mutex-0.1          |      conda_forge           3 KB  conda-forge
    _openmp_mutex-4.5          |            2_gnu          23 KB  conda-forge
    ca-certificates-2025.6.15  |       hbd8a1cb_0         148 KB  conda-forge
    cffi-1.15.1                |   py37h43b0acd_1         227 KB  conda-forge
    ld_impl_linux-64-2.40      |       hf3520f5_7         691 KB  conda-forge
    libblas-3.9.0              |31_h59b9bed_openblas          16 KB  conda-forge
    libcblas-3.9.0             |31_he106b2a_openblas          16 KB  conda-forge
    libffi-3.4.2               |       h7f98852_5          57 KB  conda-forge
    libgcc-14.2.0              |       h77fa898_1         829 KB  conda-forge
    libgcc-ng-14.2.0           |       h69a702a_1          53 KB  conda-forge
    libgfortran-14.2.0         |       h69a702a_1          53 KB  conda-forge
    libgfortran-ng-14.2.0      |       h69a702a_1          53 KB  conda-forge
    libgfortran5-14.2.0        |       hd5240d6_1         1.4 MB  conda-forge
    libgomp-14.2.0             |       h77fa898_1         450 KB  conda-forge
    liblapack-3.9.0            |31_h7ac8fdf_openblas          16 KB  conda-forge
    libnsl-2.0.1               |       hd590300_0          33 KB  conda-forge
    libopenblas-0.3.29         |       ha39b09d_0         6.5 MB
    libsqlite-3.46.0           |       hde9e2c9_0         845 KB  conda-forge
    libstdcxx-14.2.0           |       hc0a3c3a_1         3.7 MB  conda-forge
    libstdcxx-ng-14.2.0        |       h4852527_1          53 KB  conda-forge
    libzlib-1.3.1              |       h4ab18f5_1          60 KB  conda-forge
    ncurses-6.5                |       h59595ed_0         867 KB  conda-forge
    ninja-1.12.1               |       h297d8ca_0         2.1 MB  conda-forge
    numpy-1.21.6               |   py37h976b520_0         6.1 MB  conda-forge
    openssl-3.3.1              |       h4ab18f5_1         2.8 MB  conda-forge
    pip-24.0                   |     pyhd8ed1ab_0         1.3 MB  conda-forge
    pycparser-2.21             |     pyhd8ed1ab_0         100 KB  conda-forge
    python-3.7.12              |hf930737_100_cpython        57.3 MB  conda-forge
    python_abi-3.7             |          4_cp37m           6 KB  conda-forge
    pytorch-cpu-1.1.0          |   py37he1b5a44_0        50.7 MB  conda-forge <<<<<<<<<<<<
    readline-8.2               |       h8c095d6_2         276 KB  conda-forge
    setuptools-69.0.3          |     pyhd8ed1ab_0         460 KB  conda-forge
    sqlite-3.46.0              |       h6d4b2fc_0         840 KB  conda-forge
    tk-8.6.13                  |noxft_h4845f30_101         3.2 MB  conda-forge
    wheel-0.42.0               |     pyhd8ed1ab_0          56 KB  conda-forge
    xz-5.2.6                   |       h166bdaf_0         409 KB  conda-forge
    ------------------------------------------------------------
                                           Total:       141.5 MB
```

This should also be fixed in the repodata patches to remove this `track_feature` field from all packages. If this is considered as the fix, I'll make the PR there aswell.

