### PR TITLE
Fix dot on MKL builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,6 +67,8 @@ source:
       - patches/0015-Do-not-check-out-nccl-when-not-building-it.patch
       # skip a test that fails with numpy 2.3; can be dropped for pytorch>2.7
       - patches/0016-skip-test_norm_matrix_degenerate_shapes-on-numpy-2.3.patch
+      # backport https://github.com/pytorch/pytorch/pull/127702
+      - patches/0017-Define-PY_SSIZE_T_CLEAN-before-include-Python.h.patch
       - patches_submodules/fbgemm/0001-remove-DESTINATION-lib-from-CMake-install-directives.patch     # [win]
       - patches_submodules/tensorpipe/0001-switch-away-from-find_package-CUDA.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -403,6 +403,7 @@ outputs:
         # We have had issues with openmp .dylibs being doubly loaded in certain cases. These two tests catch the (observed) issue
         - python -c "import torch; import numpy"
         - python -c "import numpy; import torch"
+        - python -c "import numpy as np;import torch;x = torch.tensor([2], dtype=torch.complex128);assert torch.dot(x, x).real == 4.0"
         # distributed support is enabled by default on linux; for mac, we enable it manually in build.sh
         - python -c "import torch; assert torch.distributed.is_available()"         # [linux or osx]
         - python -c "import torch; assert torch.backends.cuda.is_built()"           # [cuda_compiler_version != "None"]

--- a/recipe/patches/0001-Force-usage-of-python-3-and-error-without-numpy.patch
+++ b/recipe/patches/0001-Force-usage-of-python-3-and-error-without-numpy.patch
@@ -1,14 +1,14 @@
-From c559bd443998c2910991c07245fdc15e4fe1fcdd Mon Sep 17 00:00:00 2001
+From c7b809486c9401ea5a9abaaf598803c88a9d7da5 Mon Sep 17 00:00:00 2001
 From: Mark Harfouche <mark.harfouche@gmail.com>
 Date: Sun, 1 Sep 2024 17:35:40 -0400
-Subject: [PATCH 01/16] Force usage of python 3 and error without numpy
+Subject: [PATCH 01/17] Force usage of python 3 and error without numpy
 
 ---
  cmake/Dependencies.cmake | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
-index be45936a8ea..4bc52c05d87 100644
+index 5227204b041..47917899943 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
 @@ -871,9 +871,9 @@ if(BUILD_PYTHON)

--- a/recipe/patches/0002-Help-find-numpy.patch
+++ b/recipe/patches/0002-Help-find-numpy.patch
@@ -1,7 +1,7 @@
-From 5f3b9a4f650af3e04f372976c25029c069d620a9 Mon Sep 17 00:00:00 2001
+From dbafa6c2e900de35d5d4b2633bf80669dde3c9d6 Mon Sep 17 00:00:00 2001
 From: Mark Harfouche <mark.harfouche@gmail.com>
 Date: Tue, 1 Oct 2024 00:28:40 -0400
-Subject: [PATCH 02/16] Help find numpy
+Subject: [PATCH 02/17] Help find numpy
 
 ---
  tools/setup_helpers/cmake.py | 6 ++++++

--- a/recipe/patches/0003-Fix-duplicate-linker-script.patch
+++ b/recipe/patches/0003-Fix-duplicate-linker-script.patch
@@ -1,7 +1,7 @@
-From f5156dc8c73d723b33a7803d0a02573cd37dbb74 Mon Sep 17 00:00:00 2001
+From c244e05d6bbef0b34777ec15ff98ae69bcc5db86 Mon Sep 17 00:00:00 2001
 From: Jeongseok Lee <jeongseok@meta.com>
 Date: Sun, 3 Nov 2024 01:12:36 -0700
-Subject: [PATCH 03/16] Fix duplicate linker script
+Subject: [PATCH 03/17] Fix duplicate linker script
 
 ---
  setup.py | 4 +++-

--- a/recipe/patches/0004-Allow-overriding-CUDA-related-paths.patch
+++ b/recipe/patches/0004-Allow-overriding-CUDA-related-paths.patch
@@ -1,7 +1,7 @@
-From 031628829de451eae20fd8a49a2785015b40af5e Mon Sep 17 00:00:00 2001
+From 45c8ecafa220144796b462cab59e9457e893bf05 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
 Date: Wed, 27 Nov 2024 13:47:23 +0100
-Subject: [PATCH 04/16] Allow overriding CUDA-related paths
+Subject: [PATCH 04/17] Allow overriding CUDA-related paths
 
 ---
  cmake/Modules/FindCUDAToolkit.cmake | 2 +-

--- a/recipe/patches/0005-Use-BLAS_USE_CBLAS_DOT-for-OpenBLAS-builds.patch
+++ b/recipe/patches/0005-Use-BLAS_USE_CBLAS_DOT-for-OpenBLAS-builds.patch
@@ -1,7 +1,7 @@
-From 1572b5d176f17e2a4ebe7c859e8c2aa19607190a Mon Sep 17 00:00:00 2001
+From c36fe22f0b7a8d95ba04b6c3c8358a70a552ff71 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <ifernando@quansight.com>
 Date: Wed, 18 Dec 2024 03:59:00 +0000
-Subject: [PATCH 05/16] Use BLAS_USE_CBLAS_DOT for OpenBLAS builds
+Subject: [PATCH] Use BLAS_USE_CBLAS_DOT for OpenBLAS builds
 
 There are two calling conventions for *dotu functions
 
@@ -27,11 +27,11 @@ assists with the BLAS switching mechanism as we are not relying on
 a particular `cdotu` implementation with the cost of two additional
 functional calls.
 ---
- cmake/Dependencies.cmake | 1 +
- 1 file changed, 1 insertion(+)
+ cmake/Dependencies.cmake | 2 ++
+ 1 file changed, 2 insertions(+)
 
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
-index 4bc52c05d87..c356c7cdfe2 100644
+index 5227204b041..d800e950540 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
 @@ -182,6 +182,7 @@ elseif(BLAS STREQUAL "OpenBLAS")
@@ -42,3 +42,14 @@ index 4bc52c05d87..c356c7cdfe2 100644
  elseif(BLAS STREQUAL "BLIS")
    find_package(BLIS REQUIRED)
    include_directories(SYSTEM ${BLIS_INCLUDE_DIR})
+@@ -204,6 +205,7 @@ elseif(BLAS STREQUAL "MKL")
+     set(BLAS_INFO "mkl")
+     set(BLAS_FOUND 1)
+     set(BLAS_LIBRARIES ${MKL_LIBRARIES})
++    set(BLAS_USE_CBLAS_DOT TRUE)
+   else()
+     message(WARNING "MKL could not be found. Defaulting to Eigen")
+     set(CAFFE2_USE_EIGEN_FOR_BLAS ON)
+-- 
+2.47.1
+

--- a/recipe/patches/0005-Use-BLAS_USE_CBLAS_DOT-for-OpenBLAS-builds.patch
+++ b/recipe/patches/0005-Use-BLAS_USE_CBLAS_DOT-for-OpenBLAS-builds.patch
@@ -1,7 +1,7 @@
-From c36fe22f0b7a8d95ba04b6c3c8358a70a552ff71 Mon Sep 17 00:00:00 2001
+From 9e6e570d3cd3b068ce06885b78ce54e26bd6928f Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <ifernando@quansight.com>
 Date: Wed, 18 Dec 2024 03:59:00 +0000
-Subject: [PATCH] Use BLAS_USE_CBLAS_DOT for OpenBLAS builds
+Subject: [PATCH 05/17] Use BLAS_USE_CBLAS_DOT for OpenBLAS builds
 
 There are two calling conventions for *dotu functions
 
@@ -31,7 +31,7 @@ functional calls.
  1 file changed, 2 insertions(+)
 
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
-index 5227204b041..d800e950540 100644
+index 47917899943..9886a284d4e 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
 @@ -182,6 +182,7 @@ elseif(BLAS STREQUAL "OpenBLAS")
@@ -50,6 +50,3 @@ index 5227204b041..d800e950540 100644
    else()
      message(WARNING "MKL could not be found. Defaulting to Eigen")
      set(CAFFE2_USE_EIGEN_FOR_BLAS ON)
--- 
-2.47.1
-

--- a/recipe/patches/0006-fix-issue-142484.patch
+++ b/recipe/patches/0006-fix-issue-142484.patch
@@ -1,7 +1,7 @@
-From 46719673ce79f2a8abe546502f18e0f324fb5e47 Mon Sep 17 00:00:00 2001
+From 93fb01e3ef83d8deefc717c771aa9d3fd905da3e Mon Sep 17 00:00:00 2001
 From: "Zheng, Zhaoqiong" <zhaoqiong.zheng@intel.com>
 Date: Fri, 27 Dec 2024 13:49:36 +0800
-Subject: [PATCH 06/16] fix issue 142484
+Subject: [PATCH 06/17] fix issue 142484
 
 From https://github.com/pytorch/pytorch/pull/143894
 ---

--- a/recipe/patches/0007-Fix-FindOpenBLAS.patch
+++ b/recipe/patches/0007-Fix-FindOpenBLAS.patch
@@ -1,7 +1,7 @@
-From a851c7801c7c6d29a2e620a80067e975bbd9bd96 Mon Sep 17 00:00:00 2001
+From 1a2259bd3d5e0820122721c9b31f04979c87ea3d Mon Sep 17 00:00:00 2001
 From: Bas Zalmstra <bas@prefix.dev>
 Date: Thu, 16 May 2024 10:46:49 +0200
-Subject: [PATCH 07/16] Fix FindOpenBLAS
+Subject: [PATCH 07/17] Fix FindOpenBLAS
 
 ---
  cmake/Modules/FindOpenBLAS.cmake | 15 +++++++++------

--- a/recipe/patches/0008-point-include-paths-to-PREFIX-include.patch
+++ b/recipe/patches/0008-point-include-paths-to-PREFIX-include.patch
@@ -1,7 +1,7 @@
-From 0fc66dec5492489915e2a08dfbdd22930dbd51aa Mon Sep 17 00:00:00 2001
+From c0da591c99f601fc2c5cc2b1c50b6d51052c8e5e Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Thu, 23 Jan 2025 22:58:14 +1100
-Subject: [PATCH 08/16] point include paths to $PREFIX/include
+Subject: [PATCH 08/17] point include paths to $PREFIX/include
 
 ---
  torch/utils/cpp_extension.py | 18 ++++++++++++++++++

--- a/recipe/patches/0009-Add-conda-prefix-to-inductor-include-paths.patch
+++ b/recipe/patches/0009-Add-conda-prefix-to-inductor-include-paths.patch
@@ -1,7 +1,7 @@
-From c8802308e80654f8a63b03d646ae3e67113c5a2d Mon Sep 17 00:00:00 2001
+From 28ae8ad0c497050f6ca371a58eddc2fc1798b9bb Mon Sep 17 00:00:00 2001
 From: Daniel Petry <dpetry@anaconda.com>
 Date: Tue, 21 Jan 2025 17:45:23 -0600
-Subject: [PATCH 09/16] Add conda prefix to inductor include paths
+Subject: [PATCH 09/17] Add conda prefix to inductor include paths
 
 Currently inductor doesn't look in conda's includes and libs. This results in
 errors when it tries to compile, if system versions are being used of

--- a/recipe/patches/0010-make-ATEN_INCLUDE_DIR-relative-to-TORCH_INSTALL_PREF.patch
+++ b/recipe/patches/0010-make-ATEN_INCLUDE_DIR-relative-to-TORCH_INSTALL_PREF.patch
@@ -1,7 +1,7 @@
-From 2dfd80a90f1d1728ccf692feba927aa8d0033313 Mon Sep 17 00:00:00 2001
+From c05d9e91805271410026fff8b9d6969d5d8d86fa Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Tue, 28 Jan 2025 14:15:34 +1100
-Subject: [PATCH 10/16] make ATEN_INCLUDE_DIR relative to TORCH_INSTALL_PREFIX
+Subject: [PATCH 10/17] make ATEN_INCLUDE_DIR relative to TORCH_INSTALL_PREFIX
 
 we cannot set CMAKE_INSTALL_PREFIX without the pytorch build complaining, but we can
 use TORCH_INSTALL_PREFIX, which is set correctly relative to our CMake files already:

--- a/recipe/patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch
+++ b/recipe/patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch
@@ -1,7 +1,7 @@
-From f59f38ebfc08d6d75a63ea1e122efa0e1155bd82 Mon Sep 17 00:00:00 2001
+From b3cbb135f98bdb7de641bf355486f79fbb3e9b72 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Tue, 28 Jan 2025 10:58:29 +1100
-Subject: [PATCH 11/16] remove `DESTINATION lib` from CMake `install(TARGETS`
+Subject: [PATCH 11/17] remove `DESTINATION lib` from CMake `install(TARGETS`
  directives
 
 Suggested-By: Silvio Traversaro <silvio@traversaro.it>

--- a/recipe/patches/0012-avoid-deprecated-find_package-CUDA-in-caffe2-CMake-m.patch
+++ b/recipe/patches/0012-avoid-deprecated-find_package-CUDA-in-caffe2-CMake-m.patch
@@ -1,7 +1,7 @@
-From b326cf46918bd84bf052a72e76989d123788375c Mon Sep 17 00:00:00 2001
+From 4d94092be5f26d1df1257c9629172fe6c62e19fc Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Thu, 30 Jan 2025 08:33:44 +1100
-Subject: [PATCH 12/16] avoid deprecated `find_package(CUDA)` in caffe2 CMake
+Subject: [PATCH 12/17] avoid deprecated `find_package(CUDA)` in caffe2 CMake
  metadata
 
 vendor the not-available-anymore function torch_cuda_get_nvcc_gencode_flag from CMake

--- a/recipe/patches/0013-Fix-CUPTI-lookup-to-include-target-directory.patch
+++ b/recipe/patches/0013-Fix-CUPTI-lookup-to-include-target-directory.patch
@@ -1,17 +1,17 @@
-From fc1c651d68ac35693d9a22aeac26065637444af5 Mon Sep 17 00:00:00 2001
+From 77d7e436f012413bb61c000c750f461b03f6696b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
 Date: Thu, 6 Mar 2025 13:57:25 +0100
-Subject: [PATCH 13/16] Fix CUPTI lookup to include target directory
+Subject: [PATCH 13/17] Fix CUPTI lookup to include target directory
 
 ---
  cmake/Dependencies.cmake | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
-index c356c7cdfe2..24976a49efe 100644
+index 9886a284d4e..8c60f9d1204 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
-@@ -1662,6 +1662,7 @@ if(USE_KINETO)
+@@ -1666,6 +1666,7 @@ if(USE_KINETO)
      endif()
  
      find_library(CUPTI_LIBRARY_PATH ${CUPTI_LIB_NAME} PATHS
@@ -19,7 +19,7 @@ index c356c7cdfe2..24976a49efe 100644
          ${CUDA_SOURCE_DIR}
          ${CUDA_SOURCE_DIR}/extras/CUPTI/lib64
          ${CUDA_SOURCE_DIR}/lib
-@@ -1669,6 +1670,7 @@ if(USE_KINETO)
+@@ -1673,6 +1674,7 @@ if(USE_KINETO)
          NO_DEFAULT_PATH)
  
      find_path(CUPTI_INCLUDE_DIR cupti.h PATHS

--- a/recipe/patches/0014-Always-use-system-nvtx.patch
+++ b/recipe/patches/0014-Always-use-system-nvtx.patch
@@ -1,7 +1,7 @@
-From 9640280046f398cacb4de4b436b27954762d38c3 Mon Sep 17 00:00:00 2001
+From b3371dcb971658239ce8aa8f6fa0a4d7bcea6735 Mon Sep 17 00:00:00 2001
 From: Jeongseok Lee <jeongseok@meta.com>
 Date: Sat, 22 Mar 2025 22:50:49 -0700
-Subject: [PATCH 14/16] Always use system nvtx
+Subject: [PATCH 14/17] Always use system nvtx
 
 ---
  cmake/public/cuda.cmake | 2 +-

--- a/recipe/patches/0015-Do-not-check-out-nccl-when-not-building-it.patch
+++ b/recipe/patches/0015-Do-not-check-out-nccl-when-not-building-it.patch
@@ -1,7 +1,7 @@
-From 33d05f2a0869d6207cd11d9460703d3ee298ef0e Mon Sep 17 00:00:00 2001
+From 647a6da2006050b4983cab517167105d6b4badfe Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
 Date: Wed, 30 Apr 2025 17:11:56 +0200
-Subject: [PATCH 15/16] Do not check out nccl when not building it
+Subject: [PATCH 15/17] Do not check out nccl when not building it
 
 Add additional conditions to `build_pytorch_libs.py` to avoid fetching
 NCCL when `USE_CUDA` or `USE_NCCL` are disabled. While at it, adjust

--- a/recipe/patches/0016-skip-test_norm_matrix_degenerate_shapes-on-numpy-2.3.patch
+++ b/recipe/patches/0016-skip-test_norm_matrix_degenerate_shapes-on-numpy-2.3.patch
@@ -1,7 +1,7 @@
-From 250de80e0cb01749b089758c9cae92e46a6ca1f5 Mon Sep 17 00:00:00 2001
+From 2e509a92b1d1a5f40de6d9a7e84f384f82b9bfdb Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sat, 14 Jun 2025 07:34:48 +1100
-Subject: [PATCH 16/16] skip test_norm_matrix_degenerate_shapes on numpy >=2.3
+Subject: [PATCH 16/17] skip test_norm_matrix_degenerate_shapes on numpy >=2.3
 
 ---
  test/test_linalg.py | 1 +

--- a/recipe/patches/0017-Define-PY_SSIZE_T_CLEAN-before-include-Python.h.patch
+++ b/recipe/patches/0017-Define-PY_SSIZE_T_CLEAN-before-include-Python.h.patch
@@ -1,0 +1,22 @@
+From 1cf62e3df7e6a08523935caa0c1a4caf95d6b0c9 Mon Sep 17 00:00:00 2001
+From: LWisteria <lwisteria.ao@gmail.com>
+Date: Sun, 2 Jun 2024 19:13:23 +0900
+Subject: [PATCH 17/17] Define PY_SSIZE_T_CLEAN before #include <Python.h>
+
+See https://docs.python.org/3/c-api/intro.html#include-files
+---
+ torch/csrc/python_headers.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/torch/csrc/python_headers.h b/torch/csrc/python_headers.h
+index 0130e41ccb4..268aa85ed52 100644
+--- a/torch/csrc/python_headers.h
++++ b/torch/csrc/python_headers.h
+@@ -9,6 +9,7 @@
+ #undef _XOPEN_SOURCE
+ #undef _POSIX_C_SOURCE
+ 
++#define PY_SSIZE_T_CLEAN
+ #include <Python.h>
+ #include <frameobject.h>
+ #include <structseq.h>


### PR DESCRIPTION
Not sure why MKL_INTERFACE_LAYER used by libmkl_rt.so (linked to by numpy) would affect libmkl_intel_gf.so (linked to by pytorch). It didn't use to. Might be a bug/feature in newer MKL.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
