### PR TITLE
[skip ci] move to activation json

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,9 +1,0 @@
-@echo off
-
-if not defined CF_TORCH_CUDA_ARCH_LIST (
-    set "CF_TORCH_CUDA_ARCH_LIST=@cf_torch_cuda_arch_list@"
-    :: "NOT_SET" is used as the value because it is clearer (explicit) that the activation
-    :: script was run and found no previous value for "CF_TORCH_CUDA_ARCH_LIST".
-    set "CF_TORCH_CUDA_ARCH_LIST_BACKUP=NOT_SET"
-)
-

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if [[ ! -v CF_TORCH_CUDA_ARCH_LIST ]]
-then
-    export CF_TORCH_CUDA_ARCH_LIST="@cf_torch_cuda_arch_list@"
-    # "NOT_SET" is used as the value because it is clearer (explicit) that the activation
-    # script was run and found no previous value for "CF_TORCH_CUDA_ARCH_LIST".
-    export CF_TORCH_CUDA_ARCH_LIST_BACKUP="NOT_SET"
-fi

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -231,16 +231,7 @@ if "%PKG_NAME%" == "libtorch" (
     if %ERRORLEVEL% neq 0 exit 1
 
     if not "%cuda_compiler_version%" == "None" (
-        sed -e "s/@cf_torch_cuda_arch_list@/%TORCH_CUDA_ARCH_LIST%/g" ^
-            %RECIPE_DIR%\activate.bat > %RECIPE_DIR%\activate-replaced.bat
-        if %ERRORLEVEL% neq 0 exit 1
-
-        mkdir %PREFIX%\etc\conda\activate.d
-        copy %RECIPE_DIR%\activate-replaced.bat %PREFIX%\etc\conda\activate.d\libtorch_activate.bat
-        if %ERRORLEVEL% neq 0 exit 1
-
-        mkdir %PREFIX%\etc\conda\deactivate.d
-        copy %RECIPE_DIR%\deactivate.bat %PREFIX%\etc\conda\deactivate.d\libtorch_deactivate.bat
+        %PYTHON% %RECIPE_DIR%\write_activation_json.py
         if %ERRORLEVEL% neq 0 exit 1
     )
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -231,7 +231,7 @@ if "%PKG_NAME%" == "libtorch" (
     if %ERRORLEVEL% neq 0 exit 1
 
     if not "%cuda_compiler_version%" == "None" (
-        %PYTHON% %RECIPE_DIR%\write_activation_json.py
+        python %RECIPE_DIR%\write_activation_json.py
         if %ERRORLEVEL% neq 0 exit 1
     )
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -298,12 +298,7 @@ case ${PKG_NAME} in
     cp build/CMakeCache.txt build/CMakeCache.txt.orig
 
     if [[ "${cuda_compiler_version}" != "None" ]]; then
-        for CHANGE in "activate" "deactivate"
-        do
-            mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
-            sed -e "s/@cf_torch_cuda_arch_list@/${TORCH_CUDA_ARCH_LIST}/g" \
-            "${RECIPE_DIR}/${CHANGE}.sh" > "${PREFIX}/etc/conda/${CHANGE}.d/libtorch_${CHANGE}.sh"
-        done
+        $PREFIX/bin/python ${RECIPE_DIR}/write_activation_json.py
     fi
 
     ;;

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -298,7 +298,7 @@ case ${PKG_NAME} in
     cp build/CMakeCache.txt build/CMakeCache.txt.orig
 
     if [[ "${cuda_compiler_version}" != "None" ]]; then
-        $PREFIX/bin/python ${RECIPE_DIR}/write_activation_json.py
+        python ${RECIPE_DIR}/write_activation_json.py
     fi
 
     ;;

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,6 +1,0 @@
-@echo off
-
-if "%CF_TORCH_CUDA_ARCH_LIST_BACKUP%" == "NOT_SET" (
-    set "CF_TORCH_CUDA_ARCH_LIST="
-    set "CF_TORCH_CUDA_ARCH_LIST_BACKUP="
-)

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-if [[ "${CF_TORCH_CUDA_ARCH_LIST_BACKUP:-}" == "NOT_SET" ]]
-then
-  unset CF_TORCH_CUDA_ARCH_LIST
-  unset CF_TORCH_CUDA_ARCH_LIST_BACKUP
-fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -226,6 +226,11 @@ test:
     - test -f $PREFIX/share/cmake/Torch/TorchConfig.cmake                       # [linux]
     - if not exist %LIBRARY_PREFIX%\share\cmake\Torch\TorchConfig.cmake exit 1  # [win]
 
+    # env_vars.d JSON sets CF_TORCH_CUDA_ARCH_LIST on activation
+    - test -f $PREFIX/etc/conda/env_vars.d/libtorch.json                                                                                                                                                                                                    # [cuda_compiler_version != "None" and unix]
+    - if not exist %PREFIX%\etc\conda\env_vars.d\libtorch.json exit 1                                                                                                                                                                                       # [cuda_compiler_version != "None" and win]
+    - python -c "import json, os, pathlib; d=json.loads((pathlib.Path(os.environ['PREFIX']) / 'etc' / 'conda' / 'env_vars.d' / 'libtorch.json').read_text()); assert 'CF_TORCH_CUDA_ARCH_LIST' in d and d['CF_TORCH_CUDA_ARCH_LIST'], repr(d)"              # [cuda_compiler_version != "None"]
+
     # test integrity of CMake metadata
     - cd cmake_test
     - cmake -GNinja -DCMAKE_CXX_STANDARD=17 $CMAKE_ARGS .   # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -227,9 +227,7 @@ test:
     - if not exist %LIBRARY_PREFIX%\share\cmake\Torch\TorchConfig.cmake exit 1  # [win]
 
     # env_vars.d JSON sets CF_TORCH_CUDA_ARCH_LIST on activation
-    - test -f $PREFIX/etc/conda/env_vars.d/libtorch.json                                                                                                                                                                                                    # [cuda_compiler_version != "None" and unix]
-    - if not exist %PREFIX%\etc\conda\env_vars.d\libtorch.json exit 1                                                                                                                                                                                       # [cuda_compiler_version != "None" and win]
-    - python -c "import json, os, pathlib; d=json.loads((pathlib.Path(os.environ['PREFIX']) / 'etc' / 'conda' / 'env_vars.d' / 'libtorch.json').read_text()); assert 'CF_TORCH_CUDA_ARCH_LIST' in d and d['CF_TORCH_CUDA_ARCH_LIST'], repr(d)"              # [cuda_compiler_version != "None"]
+    - python -c "import os; v = os.environ.get('CF_TORCH_CUDA_ARCH_LIST'); assert v, f'CF_TORCH_CUDA_ARCH_LIST not set or empty (got {v!r})'"  # [cuda_compiler_version != "None"]
 
     # test integrity of CMake metadata
     - cd cmake_test

--- a/recipe/write_activation_json.py
+++ b/recipe/write_activation_json.py
@@ -1,0 +1,14 @@
+"""Write $PREFIX/etc/conda/env_vars.d/libtorch.json with build-time env vars."""
+import json
+import os
+import pathlib
+
+prefix = os.environ["PREFIX"]
+torch_cuda_arch_list = os.environ["TORCH_CUDA_ARCH_LIST"]
+
+env_vars_d = pathlib.Path(prefix) / "etc" / "conda" / "env_vars.d"
+env_vars_d.mkdir(parents=True, exist_ok=True)
+
+output = {"CF_TORCH_CUDA_ARCH_LIST": torch_cuda_arch_list}
+(env_vars_d / "libtorch.json").write_text(json.dumps(output, indent=2))
+print(f"Wrote {env_vars_d / 'libtorch.json'}: {output}")


### PR DESCRIPTION
The activation scripts were pretty weird and broken.

The "backup" was never useful (we never overwrote the flags anyways).

The `sed` command didn't work on Windows.

This is an attempt to use the `env_vars.d` JSON files instead and write the values properly using a little Python helper script.