### PR TITLE
[v2.11.x] Rebuild for libabseil 20260526 & libprotobuf 7.35.1

### DIFF
--- a/.ci_support/linux_64_blas_implgenericc_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_version12.9is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_version12.9is_rcFalse.yaml
@@ -29,7 +29,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libblas:
 - 3.9.* *netlib
 libcblas:
@@ -43,7 +43,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 mkl:

--- a/.ci_support/linux_64_blas_implgenericc_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_versionNoneis_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_versionNoneis_rcFalse.yaml
@@ -29,7 +29,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libblas:
 - 3.9.* *netlib
 libcblas:
@@ -43,7 +43,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 mkl:

--- a/.ci_support/linux_64_blas_implgenericc_stdlib_version2.28channel_targetsconda-forge_maincuda_compiler_version13.0is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implgenericc_stdlib_version2.28channel_targetsconda-forge_maincuda_compiler_version13.0is_rcFalse.yaml
@@ -29,7 +29,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libblas:
 - 3.9.* *netlib
 libcblas:
@@ -43,7 +43,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 mkl:

--- a/.ci_support/linux_64_blas_implmklc_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_version12.9is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implmklc_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_version12.9is_rcFalse.yaml
@@ -29,7 +29,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libblas:
 - 3.9.* *netlib
 libcblas:
@@ -43,7 +43,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 mkl:

--- a/.ci_support/linux_64_blas_implmklc_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_versionNoneis_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implmklc_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_versionNoneis_rcFalse.yaml
@@ -29,7 +29,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libblas:
 - 3.9.* *netlib
 libcblas:
@@ -43,7 +43,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 mkl:

--- a/.ci_support/linux_64_blas_implmklc_stdlib_version2.28channel_targetsconda-forge_maincuda_compiler_version13.0is_rcFalse.yaml
+++ b/.ci_support/linux_64_blas_implmklc_stdlib_version2.28channel_targetsconda-forge_maincuda_compiler_version13.0is_rcFalse.yaml
@@ -29,7 +29,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libblas:
 - 3.9.* *netlib
 libcblas:
@@ -43,7 +43,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 mkl:

--- a/.ci_support/linux_aarch64_arm_variant_typesbsac_compiler_version14c_stdlib_version2.28channel_targetsconda-forge_maincuda_compiler_version13.0cxx_compiler_version14is_rcFalse.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_typesbsac_compiler_version14c_stdlib_version2.28channel_targetsconda-forge_maincuda_compiler_version13.0cxx_compiler_version14is_rcFalse.yaml
@@ -5,7 +5,7 @@ blas_impl:
 c_compiler:
 - gcc
 c_compiler_version:
-- '13'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -21,7 +21,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '13'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fmt:

--- a/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_version12.9is_rcFalse.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_version12.9is_rcFalse.yaml
@@ -1,5 +1,5 @@
 arm_variant_type:
-- tegra
+- sbsa
 blas_impl:
 - generic
 c_compiler:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.34'
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -31,7 +31,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libblas:
 - 3.9.* *netlib
 libcblas:
@@ -45,7 +45,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 mkl:

--- a/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_versionNoneis_rcFalse.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_versionNoneis_rcFalse.yaml
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.28'
+- '2.17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,7 +17,7 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '13.0'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -31,7 +31,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libblas:
 - 3.9.* *netlib
 libcblas:
@@ -45,7 +45,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 mkl:

--- a/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.28channel_targetsconda-forge_maincuda_compiler_version13.0is_rcFalse.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.28channel_targetsconda-forge_maincuda_compiler_version13.0is_rcFalse.yaml
@@ -5,11 +5,11 @@ blas_impl:
 c_compiler:
 - gcc
 c_compiler_version:
-- '13'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,11 +17,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.9'
+- '13.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '13'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fmt:
@@ -31,7 +31,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libblas:
 - 3.9.* *netlib
 libcblas:
@@ -45,7 +45,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 mkl:

--- a/.ci_support/linux_aarch64_arm_variant_typetegrac_stdlib_version2.34channel_targetsconda-forge_maincuda_compiler_version12.9is_rcFalse.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_typetegrac_stdlib_version2.34channel_targetsconda-forge_maincuda_compiler_version12.9is_rcFalse.yaml
@@ -1,15 +1,15 @@
 arm_variant_type:
-- sbsa
+- tegra
 blas_impl:
 - generic
 c_compiler:
 - gcc
 c_compiler_version:
-- '13'
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.34'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,11 +17,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- None
+- '12.9'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '13'
+- '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fmt:
@@ -31,7 +31,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libblas:
 - 3.9.* *netlib
 libcblas:
@@ -45,7 +45,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 mkl:

--- a/.ci_support/migrations/absl_grpc_proto_26Q2.yaml
+++ b/.ci_support/migrations/absl_grpc_proto_26Q2.yaml
@@ -1,0 +1,30 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libabseil 20260526, libgrpc 1.82 & libprotobuf 7.35.1
+  kind: version
+  migration_number: 1
+  paused: true
+  exclude:
+    # core deps
+    - abseil-cpp
+    - grpc-cpp
+    - libprotobuf
+    # required for building/testing
+    - protobuf
+    - re2
+    # bazel stack
+    - bazel
+    - grpc_java_plugin
+    - singlejar
+    # built manually beforehand due to enormous build time
+    - pytorch-cpu
+libabseil:
+- 20260526
+libgrpc:
+- "1.82"
+libprotobuf:
+- 7.35.1
+# https://github.com/protocolbuffers/protobuf/commit/66a9ea7540ad7d3d0822ace6fc8d9ba6cd088c4d
+c_stdlib_version:   # [osx]
+  - 12.0            # [osx]
+migrator_ts: 1775539322.336586

--- a/.ci_support/migrations/cuda130.yaml
+++ b/.ci_support/migrations/cuda130.yaml
@@ -6,7 +6,6 @@ __migrator:
   build_number:
     1
   paused: false
-  use_local: true
   override_cbc_keys:
     - cuda_compiler_stub
   check_solvable: false
@@ -53,13 +52,11 @@ cuda_compiler_version:         # [((linux and (x86_64 or aarch64)) or win64) and
 c_stdlib_version:              # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 2.28                       # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
-# Compiler pinnings deviate from global migrator in order to honor pinnings in local conda_build_config for aarch64
 c_compiler_version:            # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 14                         # [(linux and (x86_64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 13                         # [(linux and (aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
 cxx_compiler_version:          # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 14                         # [(linux and (x86_64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 13                         # [(linux and (aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 fortran_compiler_version:      # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]

--- a/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalse.yaml
+++ b/.ci_support/osx_64_blas_implgenericchannel_targetsconda-forge_mainis_rcFalse.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '12.0'
 MACOSX_SDK_VERSION:
 - '14.5'
 blas_impl:
@@ -11,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '12.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -31,7 +31,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libblas:
 - 3.9.* *netlib
 libcblas:
@@ -45,7 +45,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 llvm_openmp:

--- a/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalse.yaml
+++ b/.ci_support/osx_64_blas_implmklchannel_targetsconda-forge_mainis_rcFalse.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '12.0'
 MACOSX_SDK_VERSION:
 - '14.5'
 blas_impl:
@@ -11,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '12.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -31,7 +31,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libblas:
 - 3.9.* *netlib
 libcblas:
@@ -45,7 +45,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 llvm_openmp:

--- a/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalse.yaml
+++ b/.ci_support/osx_arm64_channel_targetsconda-forge_mainis_rcFalse.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '12.0'
 MACOSX_SDK_VERSION:
 - '14.5'
 blas_impl:
@@ -11,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '12.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -31,7 +31,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libblas:
 - 3.9.* *netlib
 libcblas:
@@ -45,7 +45,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 llvm_openmp:

--- a/.ci_support/win_64_channel_targetsconda-forge_maincuda_compiler_version12.8is_rcFalse.yaml
+++ b/.ci_support/win_64_channel_targetsconda-forge_maincuda_compiler_version12.8is_rcFalse.yaml
@@ -21,7 +21,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libcudnn_dev:
 - '9'
 libmagma_devel:
@@ -29,7 +29,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 mkl:

--- a/.ci_support/win_64_channel_targetsconda-forge_maincuda_compiler_version13.0is_rcFalse.yaml
+++ b/.ci_support/win_64_channel_targetsconda-forge_maincuda_compiler_version13.0is_rcFalse.yaml
@@ -21,7 +21,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libcudnn_dev:
 - '9'
 libmagma_devel:
@@ -29,7 +29,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 mkl:

--- a/.ci_support/win_64_channel_targetsconda-forge_maincuda_compiler_versionNoneis_rcFalse.yaml
+++ b/.ci_support/win_64_channel_targetsconda-forge_maincuda_compiler_versionNoneis_rcFalse.yaml
@@ -21,7 +21,7 @@ github_actions_labels:
 is_rc:
 - 'False'
 libabseil:
-- '20260107'
+- '20260526'
 libcudnn_dev:
 - '9'
 libmagma_devel:
@@ -29,7 +29,7 @@ libmagma_devel:
 libmagma_sparse:
 - 2.10.0
 libprotobuf:
-- 6.33.5
+- 7.35.1
 libtorch:
 - '2.10'
 mkl:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -94,7 +94,7 @@ jobs:
             tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
-          - CONFIG: linux_aarch64_arm_variant_typesbsac_compiler_version13c_stdlib_version2.28channel_targetsconda-forge_maincuda_compiler_version13.0cxx_compiler_version13is_rcFalse
+          - CONFIG: linux_aarch64_arm_variant_typesbsac_compiler_version14c_stdlib_version2.28channel_targetsconda-forge_maincuda_compiler_version13.0cxx_compiler_version14is_rcFalse
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -76,7 +76,7 @@ jobs:
             tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
-          - CONFIG: linux_aarch64_arm_variant_typesbsac_compiler_version13c_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_version12.9cxx_compiler_version13is_rcFalse
+          - CONFIG: linux_aarch64_arm_variant_typesbsac_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_version12.9is_rcFalse
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
@@ -85,7 +85,7 @@ jobs:
             tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
-          - CONFIG: linux_aarch64_arm_variant_typesbsac_compiler_version13c_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_versionNonecxx_compiler_version13is_rcFalse
+          - CONFIG: linux_aarch64_arm_variant_typesbsac_stdlib_version2.17channel_targetsconda-forge_maincuda_compiler_versionNoneis_rcFalse
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
@@ -94,7 +94,7 @@ jobs:
             tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
-          - CONFIG: linux_aarch64_arm_variant_typesbsac_compiler_version14c_stdlib_version2.28channel_targetsconda-forge_maincuda_compiler_version13.0cxx_compiler_version14is_rcFalse
+          - CONFIG: linux_aarch64_arm_variant_typesbsac_stdlib_version2.28channel_targetsconda-forge_maincuda_compiler_version13.0is_rcFalse
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
@@ -103,7 +103,7 @@ jobs:
             tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
-          - CONFIG: linux_aarch64_arm_variant_typetegrac_compiler_version14c_stdlib_version2.34channel_targetsconda-forge_maincuda_compiler_version12.9cxx_compiler_version14is_rcFalse
+          - CONFIG: linux_aarch64_arm_variant_typetegrac_stdlib_version2.34channel_targetsconda-forge_maincuda_compiler_version12.9is_rcFalse
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,4 @@
 azure:
-  free_disk_space: true
   settings_linux:
     timeoutInMinutes: 1
 bot:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,11 +1,3 @@
-# problem with GCC 14 in vendored xnnpack
-c_compiler_version:     # [aarch64]
-  - 13                  # [aarch64]
-  - 13                  # [aarch64]
-cxx_compiler_version:   # [aarch64]
-  - 13                  # [aarch64]
-  - 13                  # [aarch64]
-
 MACOSX_SDK_VERSION:         # [osx]
   - 14.5                    # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # if you wish to build release candidate number X, append the version string with "-rcX"
 {% set version = "2.11.0" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # Use a higher build number for the CUDA variant, to ensure that it's
 # preferred by conda's solver, and it's preferentially


### PR DESCRIPTION
Preparing in advance for the next abseil/proto migration. Also picking up #519, which accidentally showed that the errors with GCC 14 on aarch are now gone as of v2.11